### PR TITLE
Add a config for interchangeable blocks

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/config/Configs.java
+++ b/src/main/java/fi/dy/masa/litematica/config/Configs.java
@@ -95,6 +95,8 @@ public class Configs implements IConfigHandler
         public static final ConfigBoolean       TOOL_ITEM_ENABLED           = new ConfigBoolean("toolItemEnabled", true, "litematica.config.generic.comment.toolItemEnabled", "litematica.config.generic.prettyName.toolItemEnabled").translatedName("litematica.config.generic.name.toolItemEnabled");
         public static final ConfigString        TOOL_ITEM_COMPONENTS        = new ConfigString( "toolItemComponents", "empty", "litematica.config.generic.comment.toolItemComponents").translatedName("litematica.config.generic.name.toolItemComponents");
         public static final ConfigBoolean       UNHIDE_SCHEMATIC_PROJECTS   = new ConfigBoolean("unhideSchematicVCS", false, "litematica.config.generic.comment.unhideSchematicVCS").translatedName("litematica.config.generic.name.unhideSchematicVCS");
+        public static final ConfigBoolean       INTERCHANGE_BLOCKS          = new ConfigBoolean("interchangeBlocks", false, "litematica.config.generic.comment.interchangeBlocks").translatedName("litematica.config.generic.name.interchangeBlocks");
+        public static final ConfigStringList    INTERCHANGEABLE_BLOCKS      = new ConfigStringList("interchangeableBlocks", ImmutableList.of(), "litematica.config.generic.comment.interchangeableBlocks").translatedName("litematica.config.generic.name.interchangeableBlocks");
 
         public static final ImmutableList<IConfigBase> OPTIONS = ImmutableList.of(
                 AREAS_PER_WORLD,
@@ -165,7 +167,10 @@ public class Configs implements IConfigHandler
                 EASY_PLACE_SWAP_INTERVAL,
                 PICK_BLOCKABLE_SLOTS,
                 TOOL_ITEM,
-                TOOL_ITEM_COMPONENTS
+                TOOL_ITEM_COMPONENTS,
+
+                INTERCHANGE_BLOCKS,
+                INTERCHANGEABLE_BLOCKS
         );
     }
 

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
@@ -736,36 +736,36 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
     protected OverlayType getOverlayType(BlockState stateSchematic, BlockState stateClient)
     {
-        Boolean interchangeBlocksEnabled = Configs.Generic.INTERCHANGE_BLOCKS.getBooleanValue();
-
-        List<String> interchangeBlocksConfig = Configs.Generic.INTERCHANGEABLE_BLOCKS.getStrings();
-        List<SubstituteBlockRegestry> substitutableBlocks = new ArrayList<>();
-
-        for (String blocks : interchangeBlocksConfig) {
-            List<Block> blockList = new ArrayList<>();
-            List<TagKey<Block>> tagList = new ArrayList<>();
-            for (String value : blocks.split(",")) {
-                String trimmed = value.trim();
-                if (trimmed.startsWith("#")) {
-                    Optional<TagKey<Block>> tag = getBlockTagFromFromString(trimmed);
-                    tag.ifPresent(tagList::add);
-                } else {
-                    Optional<Block> block = getBlockFromFromString(trimmed);
-                    block.ifPresent(blockList::add);
-                }
-            }
-            substitutableBlocks.add(new SubstituteBlockRegestry(blockList, tagList));
-        }
-
-
+        boolean interchangeBlocksEnabled = Configs.Generic.INTERCHANGE_BLOCKS.getBooleanValue();
         SubstituteBlockRegestry interchangeBlocks = new SubstituteBlockRegestry();
 
-        Block schematicBlock = stateSchematic.getBlock();
+        if (interchangeBlocksEnabled) {
+            List<String> interchangeBlocksConfig = Configs.Generic.INTERCHANGEABLE_BLOCKS.getStrings();
+            List<SubstituteBlockRegestry> substitutableBlocks = new ArrayList<>();
 
-        for (SubstituteBlockRegestry blocks : substitutableBlocks) {
-            if (blocks.hasBlock(schematicBlock)) {
-                interchangeBlocks = blocks;
-                break;
+            for (String blocks : interchangeBlocksConfig) {
+                List<Block> blockList = new ArrayList<>();
+                List<TagKey<Block>> tagList = new ArrayList<>();
+                for (String value : blocks.split(",")) {
+                    String trimmed = value.trim();
+                    if (trimmed.startsWith("#")) {
+                        Optional<TagKey<Block>> tag = getBlockTagFromFromString(trimmed);
+                        tag.ifPresent(tagList::add);
+                    } else {
+                        Optional<Block> block = getBlockFromFromString(trimmed);
+                        block.ifPresent(blockList::add);
+                    }
+                }
+                substitutableBlocks.add(new SubstituteBlockRegestry(blockList, tagList));
+            }
+
+            Block schematicBlock = stateSchematic.getBlock();
+
+            for (SubstituteBlockRegestry blocks : substitutableBlocks) {
+                if (blocks.hasBlock(schematicBlock)) {
+                    interchangeBlocks = blocks;
+                    break;
+                }
             }
         }
 

--- a/src/main/java/fi/dy/masa/litematica/util/BlockUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/BlockUtils.java
@@ -1,5 +1,6 @@
 package fi.dy.masa.litematica.util;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -9,6 +10,8 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.ChestBlock;
 import net.minecraft.block.enums.ChestType;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.Property;
 import net.minecraft.util.BlockMirror;
@@ -124,5 +127,79 @@ public class BlockUtils
         StateManager<Block, BlockState> stateManager1 = state1.getBlock().getStateManager();
         StateManager<Block, BlockState> stateManager2 = state2.getBlock().getStateManager();
         return stateManager1.getProperties().equals(stateManager2.getProperties());
+    }
+
+    public static Optional<Block> getBlockFromFromString(String str)
+    {
+        int index = str.indexOf("["); // [f=b]
+        String blockName = index != -1 ? str.substring(0, index) : str;
+
+        try
+        {
+            Identifier id = Identifier.tryParse(blockName);
+
+            if (Registries.BLOCK.containsId(id))
+            {
+                Block block = Registries.BLOCK.get(id);
+
+                return Optional.of(block);
+            }
+        }
+        catch (Exception e)
+        {
+            return Optional.empty();
+        }
+
+        return Optional.empty();
+    }
+
+    public static Optional<TagKey<Block>> getBlockTagFromFromString(String str)
+    {
+        if (str.startsWith("#")) {
+            try {
+                String tagName = str.substring(1);
+                Identifier id = Identifier.tryParse(tagName);
+
+                TagKey<Block> blockTag = TagKey.of(RegistryKeys.BLOCK, id);
+                return Optional.of(blockTag);
+
+            } catch (Exception e) {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static Boolean compareBlockStates(BlockState stateA, BlockState stateB)
+    {
+        Collection<Property<?>> propertiesA = stateA.getProperties();
+        Collection<Property<?>> propertiesB = stateB.getProperties();
+
+        boolean equal = true;
+
+        if (!propertiesA.isEmpty() && !propertiesB.isEmpty())
+        {
+            if (propertiesA.containsAll(propertiesB) && propertiesB.containsAll(propertiesA)) {
+                Iterator<Property<?>> propA = propertiesA.iterator();
+                Iterator<Property<?>> propB = propertiesB.iterator();
+
+                while (propA.hasNext() && propB.hasNext()) {
+                    Property<?> pA = propA.next();
+                    Property<?> pB = propB.next();
+
+                    Comparable<?> valA = stateA.get(pA);
+                    Comparable<?> valB = stateB.get(pB);
+
+                    if (valA != valB) {
+                        equal = false;
+                    }
+                }
+            } else {
+                equal = false;
+            }
+        }
+
+        return equal;
     }
 }

--- a/src/main/java/fi/dy/masa/litematica/util/SubstituteBlockRegestry.java
+++ b/src/main/java/fi/dy/masa/litematica/util/SubstituteBlockRegestry.java
@@ -1,0 +1,37 @@
+package fi.dy.masa.litematica.util;
+
+import net.minecraft.block.Block;
+import net.minecraft.registry.tag.TagKey;
+
+import java.util.ArrayList;
+import java.util.List;
+public class SubstituteBlockRegestry {
+    private final List<Block> blocks;
+    private final List<TagKey<Block>> blockTags;
+
+    public boolean hasBlock(Block block) {
+        if (this.blocks.contains(block)) {
+            return true;
+        } else {
+            for (TagKey<Block> tag:
+                    this.blockTags){
+                if (block.getDefaultState().isIn(tag)) return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isEmpty() {
+        return this.blocks.isEmpty() && this.blockTags.isEmpty();
+    }
+
+    public SubstituteBlockRegestry(List<Block> blocks, List<TagKey<Block>> blockTags) {
+        this.blocks = blocks;
+        this.blockTags = blockTags;
+    }
+
+    public SubstituteBlockRegestry() {
+        this.blocks = new ArrayList<>();
+        this.blockTags = new ArrayList<>();
+    }
+}

--- a/src/main/resources/assets/litematica/lang/en_us.json
+++ b/src/main/resources/assets/litematica/lang/en_us.json
@@ -285,8 +285,8 @@
     "litematica.config.generic.comment.toolItemComponents": "A Data Components-aware version of toolItem.\nSet to \"empty\" to disable.\nThe syntax accepted is the same as the \"/give\" command.",
     "litematica.config.generic.comment.unhideSchematicVCS": "Un-hides the Schematic VCS (Version Control System) menu button,\nand enables the hotkey and the VCS functionality in general.\n(This was called Schematic Projects before.)\n\nIn general you §6should not§r be using this feature,\nunless you really know how it works and what it does.\nIt somewhat changes how the area selections, placements and pasting works,\nin particular that there is also an area delete operation when pasting.\n\nBasically this feature is intended for §6iterative, in-place§r design work,\nand it allows you to easier create multiple versions/snapshots\nof the same build, and also to switch between the versions by deleting what is\nin the world first, and then pasting the next version in its place.",
     
-    "litematica.config.generic.comment.interchangeBlocks": "Makes it so all blocks in each of the lists defined in interchangeableBlocks is interchangable when building a schematic, at least as far as the overlay is concerned.",
-    "litematica.config.generic.comment.interchangeableBlocks": "Lists of blocks which are interchangable.",
+    "litematica.config.generic.comment.interchangeBlocks": "Makes it so all blocks in each of the lists defined\nin interchangeableBlocks is interchangable when\nbuilding a schematic.",
+    "litematica.config.generic.comment.interchangeableBlocks": "Lists of comma-seperated block-IDs and block-tag-IDs\nwhich are considered interchangable when building\na schematic (e.g. \"minecraft:stone_slab,\nminecraft:smooth_stone_slab, #minecraft:wooden_slabs\").\nInvalid IDs are ignored.",
 
     "litematica.config.visuals.comment.enableAreaSelectionBoxesRendering": "Enable Area Selection boxes rendering",
     "litematica.config.visuals.comment.enablePlacementBoxesRendering": "Enable Schematic Placement boxes rendering",

--- a/src/main/resources/assets/litematica/lang/en_us.json
+++ b/src/main/resources/assets/litematica/lang/en_us.json
@@ -66,6 +66,8 @@
     "litematica.config.generic.name.toolItemEnabled": "toolItemEnabled",
     "litematica.config.generic.name.toolItemComponents": "toolItemComponents",
     "litematica.config.generic.name.unhideSchematicVCS": "unhideSchematicVCS",
+    "litematica.config.generic.name.interchangeBlocks": "interchangeBlocks",
+    "litematica.config.generic.name.interchangeableBlocks": "interchangeableBlocks",
 
     "litematica.config.visuals.name.enableAreaSelectionBoxesRendering": "enableAreaSelectionBoxesRendering",
     "litematica.config.visuals.name.enablePlacementBoxesRendering": "enablePlacementBoxesRendering",
@@ -282,6 +284,9 @@
     "litematica.config.generic.comment.toolItemEnabled": "If true, then the \"tool\" item can be used to control selections etc.",
     "litematica.config.generic.comment.toolItemComponents": "A Data Components-aware version of toolItem.\nSet to \"empty\" to disable.\nThe syntax accepted is the same as the \"/give\" command.",
     "litematica.config.generic.comment.unhideSchematicVCS": "Un-hides the Schematic VCS (Version Control System) menu button,\nand enables the hotkey and the VCS functionality in general.\n(This was called Schematic Projects before.)\n\nIn general you §6should not§r be using this feature,\nunless you really know how it works and what it does.\nIt somewhat changes how the area selections, placements and pasting works,\nin particular that there is also an area delete operation when pasting.\n\nBasically this feature is intended for §6iterative, in-place§r design work,\nand it allows you to easier create multiple versions/snapshots\nof the same build, and also to switch between the versions by deleting what is\nin the world first, and then pasting the next version in its place.",
+    
+    "litematica.config.generic.comment.interchangeBlocks": "Makes it so all blocks in each of the lists defined in interchangeableBlocks is interchangable when building a schematic, at least as far as the overlay is concerned.",
+    "litematica.config.generic.comment.interchangeableBlocks": "Lists of blocks which are interchangable.",
 
     "litematica.config.visuals.comment.enableAreaSelectionBoxesRendering": "Enable Area Selection boxes rendering",
     "litematica.config.visuals.comment.enablePlacementBoxesRendering": "Enable Schematic Placement boxes rendering",


### PR DESCRIPTION
This adds two new entries to the general configuration where you can add comma-separated lists of blocks and tags that are interchangeable while building.  
I found it annoying when building schematics designed in creative mode in survival because people frequently use things like smooth stone slabs or a particular type of wooden fences, etc. and I ended up using a different type so large parts of the schematic were "invalid" but functionally the same. This aims to adress that problem.