### PR TITLE
Alternative fallback block implementation POC

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/mixin/model/MixinBlockStateManagers.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/model/MixinBlockStateManagers.java
@@ -1,0 +1,33 @@
+package fi.dy.masa.litematica.mixin.model;
+
+import fi.dy.masa.litematica.Reference;
+import fi.dy.masa.litematica.render.schematic.blocks.FallbackBlocks;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.model.BlockStateManagers;
+import net.minecraft.state.StateManager;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Mixin(BlockStateManagers.class)
+public class MixinBlockStateManagers {
+
+    @Shadow private static Map<Identifier, StateManager<Block, BlockState>> STATIC_MANAGERS;
+
+    @Inject(method = "<clinit>", at = @At("RETURN"))
+    private static void staticInit(CallbackInfo ci) {
+        if (!(STATIC_MANAGERS instanceof HashMap)) {
+            STATIC_MANAGERS = new HashMap<>(STATIC_MANAGERS);
+        }
+        STATIC_MANAGERS.put(Identifier.of(Reference.MOD_ID, "black_glass_fallback"), FallbackBlocks.FAKE_BLACK_GLASS_MANAGER);
+    }
+
+}

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
@@ -211,7 +211,6 @@ public class WorldRendererSchematic
 
 	private void buildFallbackBlocks()
 	{
-		this.fallbackBlocks.put(Blocks.BLACK_STAINED_GLASS, FallbackBlocks.BLACK_GLASS);
 		this.fallbackBlocks.put(Blocks.BLUE_STAINED_GLASS, FallbackBlocks.BLUE_GLASS);
 		this.fallbackBlocks.put(Blocks.BROWN_STAINED_GLASS, FallbackBlocks.BROWN_GLASS);
 		this.fallbackBlocks.put(Blocks.CYAN_STAINED_GLASS, FallbackBlocks.CYAN_GLASS);
@@ -252,6 +251,29 @@ public class WorldRendererSchematic
 	private <T extends Comparable<T>> BlockState getFallbackState(BlockState origState)
 	{
 		Collection<Property<?>> props = origState.getProperties();
+
+        if (origState.getBlock() == Blocks.BLACK_STAINED_GLASS) {
+            BlockState newState = FallbackBlocks.FAKE_BLACK_GLASS_MANAGER.getDefaultState();
+
+            for (Property<?> entry : props)
+            {
+                @SuppressWarnings("unchecked")
+                Property<T> p = (Property<T>) entry;
+
+                if (newState.contains(p))
+                {
+                    T value = origState.get(p);
+
+                    if (!newState.get(p).equals(value))
+                    {
+                        newState = newState.with(p, value);
+                    }
+                }
+            }
+
+            Litematica.debugLog("Fallback Block State -- OLD: %s --> NEW: %s", origState.toString(), newState.toString());
+            return newState;
+        }
 
 		if (this.fallbackBlocks.containsKey(origState.getBlock()))
 		{

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/blocks/FallbackBlocks.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/blocks/FallbackBlocks.java
@@ -4,9 +4,13 @@ import java.util.function.Function;
 
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.Properties;
+import net.minecraft.state.property.Property;
 import net.minecraft.util.Identifier;
 
 import fi.dy.masa.litematica.Litematica;
@@ -17,8 +21,10 @@ import fi.dy.masa.litematica.Reference;
  */
 public class FallbackBlocks
 {
+    public static final StateManager<Block, BlockState> FAKE_BLACK_GLASS_MANAGER = new StateManager.Builder<Block, BlockState>(Blocks.AIR)
+            .build(Block::getDefaultState, BlockState::new);
+
 	// Glass Blocks
-	public static Block BLACK_GLASS = register("black_glass_fallback", FallbackTransparentBlock::new, glassSettings());
 	public static Block BLUE_GLASS = register("blue_glass_fallback", FallbackTransparentBlock::new, glassSettings());
 	public static Block BROWN_GLASS = register("brown_glass_fallback", FallbackTransparentBlock::new, glassSettings());
 	public static Block CYAN_GLASS = register("cyan_glass_fallback", FallbackTransparentBlock::new, glassSettings());

--- a/src/main/resources/litematica.accesswidener
+++ b/src/main/resources/litematica.accesswidener
@@ -1,3 +1,3 @@
 accessWidener v1 named
 accessible method net/minecraft/block/Blocks register (Lnet/minecraft/registry/RegistryKey;Ljava/util/function/Function;Lnet/minecraft/block/AbstractBlock$Settings;)Lnet/minecraft/block/Block;
-
+mutable field net/minecraft/client/render/model/BlockStateManagers STATIC_MANAGERS Ljava/util/Map;

--- a/src/main/resources/mixins.litematica.json
+++ b/src/main/resources/mixins.litematica.json
@@ -38,6 +38,7 @@
         "hud.MixinDebugHudEntries",
         "hud.MixinDebugHudProfile",
         "input.IMixinKeyBinding",
+        "model.MixinBlockStateManagers",
         "network.MixinClientCommonNetworkHandler",
         "network.MixinClientPlayNetworkHandler",
         "render.IMixinGameRenderer",


### PR DESCRIPTION
Demonstrates an alternative fallback block implementation using the same method vanilla uses for fake item frame block models. Avoids creating fake blocks which are problematic