### PR TITLE
fix: Debug cleanup, error handling, and bug fixes for 26.1

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/event/RenderHandler.java
@@ -32,7 +32,10 @@ public class RenderHandler implements IRenderer
     @Override
     public void onExtractWorldLast(DeltaTracker deltaTracker, Camera camera, float ticks, ProfilerFiller profiler)
     {
-        // TODO
+        if (Configs.Visuals.ENABLE_RENDERING.getBooleanValue() && Minecraft.getInstance().player != null)
+        {
+            LitematicaRenderer.getInstance().uploadRemainingBuffers(camera, deltaTracker, profiler);
+        }
     }
 
     @Override

--- a/src/main/java/fi/dy/masa/litematica/render/OverlayRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/OverlayRenderer.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import fi.dy.masa.litematica.Litematica;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -427,7 +428,7 @@ public class OverlayRenderer
 
                 ctx.reset();
             }
-            catch (Exception ignored) { }
+            catch (Exception e) { Litematica.LOGGER.error("Error during overlay mismatch rendering", e); }
 
             profiler.popPush("outlines");
 	        lineWidth = 6f;
@@ -448,7 +449,7 @@ public class OverlayRenderer
 
             ctx.reset();
         }
-        catch (Exception ignored) { }
+        catch (Exception e) { Litematica.LOGGER.error("Error during overlay outline rendering", e); }
 
         profiler.popPush("sides");
         if (Configs.Visuals.RENDER_ERROR_MARKER_SIDES.getBooleanValue())
@@ -476,7 +477,7 @@ public class OverlayRenderer
 
                 ctx.close();
             }
-            catch (Exception ignored) { }
+            catch (Exception e) { Litematica.LOGGER.error("Error during overlay side rendering", e); }
         }
 
         profiler.pop();

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ByteBufferBuilderCache.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ByteBufferBuilderCache.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+import fi.dy.masa.litematica.Litematica;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -95,7 +96,7 @@ public class ByteBufferBuilderCache implements AutoCloseable
                 this.blockCache.remove(layer).close();
             }
         }
-        catch (Exception ignored) { }
+        catch (Exception e) { Litematica.LOGGER.error("Error closing block buffer builder cache by layer", e); }
     }
 
     protected void closeByType(OverlayRenderType type)
@@ -107,7 +108,7 @@ public class ByteBufferBuilderCache implements AutoCloseable
                 this.overlayCache.remove(type).close();
             }
         }
-        catch (Exception ignored) { }
+        catch (Exception e) { Litematica.LOGGER.error("Error closing overlay buffer builder cache by type", e); }
     }
 
     protected boolean isClear() { return this.clear; }
@@ -119,7 +120,7 @@ public class ByteBufferBuilderCache implements AutoCloseable
             this.blockCache.values().forEach(ByteBufferBuilder::discard);
             this.overlayCache.values().forEach(ByteBufferBuilder::discard);
         }
-        catch (Exception ignored) { }
+        catch (Exception e) { Litematica.LOGGER.error("Error resetting buffer builder cache", e); }
 
         this.clear = true;
     }
@@ -131,7 +132,7 @@ public class ByteBufferBuilderCache implements AutoCloseable
             this.blockCache.values().forEach(ByteBufferBuilder::clear);
             this.overlayCache.values().forEach(ByteBufferBuilder::clear);
         }
-        catch (Exception ignored) { }
+        catch (Exception e) { Litematica.LOGGER.error("Error clearing buffer builder cache", e); }
 
         this.clear = true;
     }

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkMeshCache.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkMeshCache.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.mojang.blaze3d.vertex.MeshData;
+import fi.dy.masa.litematica.Litematica;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 
 public class ChunkMeshCache implements AutoCloseable
@@ -83,7 +84,7 @@ public class ChunkMeshCache implements AutoCloseable
         {
             list.forEach(MeshData::close);
         }
-        catch (Exception ignored) { }
+        catch (Exception e) { Litematica.LOGGER.error("Error closing chunk mesh cache", e); }
     }
 
     @Override

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkMeshDataSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkMeshDataSchematic.java
@@ -181,7 +181,7 @@ public class ChunkMeshDataSchematic implements AutoCloseable
 
 	protected void compileLayerDrawStates(Set<ChunkSectionLayer> blockLayersUsed)
 	{
-		LOGGER.warn("[Mesh] compileLayerDrawStates() --> {}", blockLayersUsed.toString());
+		LOGGER.debug("[Mesh] compileLayerDrawStates() --> {}", blockLayersUsed.toString());
 		this.blockDrawStates.clear();
 
 		for (ChunkSectionLayer layer : blockLayersUsed)
@@ -190,7 +190,7 @@ public class ChunkMeshDataSchematic implements AutoCloseable
 
 			if (meshData != null)
 			{
-				LOGGER.warn("[Mesh] compileLayerDrawStates(): layer: [{}] --> STORE", layer.label());
+				LOGGER.debug("[Mesh] compileLayerDrawStates(): layer: [{}] --> STORE", layer.label());
 				this.blockDrawStates.put(layer, new ChunkMeshDataSchematic.DrawState(meshData.drawState().indexCount(), meshData.drawState().indexType(), meshData.indexBuffer() != null));
 			}
 		}
@@ -198,7 +198,7 @@ public class ChunkMeshDataSchematic implements AutoCloseable
 
 	protected void compileOverlayDrawStates(Set<OverlayRenderType> overlaysUsed)
 	{
-		LOGGER.warn("[Mesh] compileOverlayDrawStates() --> {}", overlaysUsed.toString());
+		LOGGER.debug("[Mesh] compileOverlayDrawStates() --> {}", overlaysUsed.toString());
 		this.overlayDrawStates.clear();
 
 		for (OverlayRenderType type : overlaysUsed)
@@ -207,7 +207,7 @@ public class ChunkMeshDataSchematic implements AutoCloseable
 
 			if (meshData != null)
 			{
-				LOGGER.warn("[Mesh] compileLayerDrawStates(): type: [{}] --> STORE", type.name());
+				LOGGER.debug("[Mesh] compileLayerDrawStates(): type: [{}] --> STORE", type.name());
 				this.overlayDrawStates.put(type, new ChunkMeshDataSchematic.DrawState(meshData.drawState().indexCount(), meshData.drawState().indexType(), meshData.indexBuffer() != null));
 			}
 		}

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderBatchDraw.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderBatchDraw.java
@@ -19,6 +19,8 @@ import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.util.profiling.ProfilerFiller;
 
+import fi.dy.masa.litematica.Litematica;
+
 public record ChunkRenderBatchDraw(
 		GpuTextureView atlasTexture,
 //		EnumMap<ChunkSectionLayer, Int2ObjectOpenHashMap<List<RenderPass.Draw<GpuBufferSlice[]>>>> drawData,
@@ -107,7 +109,7 @@ public record ChunkRenderBatchDraw(
 				}
 			}
 		}
-		catch (Exception ignored) { }
+		catch (Exception e) { Litematica.LOGGER.error("Error during schematic chunk batch draw", e); }
 
         profiler.pop();
     }

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderDataSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderDataSchematic.java
@@ -67,7 +67,7 @@ public class ChunkRenderDataSchematic implements AutoCloseable
 
 	protected void updateMeshDataCache(ChunkMeshDataSchematic meshData)
 	{
-		LOGGER.warn("[RD] updateMeshDataCache()");
+		LOGGER.debug("[RD] updateMeshDataCache()");
 		if (this.meshDataCache != null || !this.meshDataCache.equals(ChunkMeshDataSchematic.EMPTY))
 		{
 			int comparator = ChunkMeshDataSchematic.COMPARATOR.compare(this.meshDataCache, meshData);

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderDispatcherLitematica.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderDispatcherLitematica.java
@@ -90,7 +90,7 @@ public class ChunkRenderDispatcherLitematica
                         BufferAllocatorCache r = this.queueFreeRenderAllocators.take();
                         r.close();
                     }
-                    catch (Exception ignored) { }
+                    catch (Exception e) { Litematica.LOGGER.error("Error closing free render allocator", e); }
 
                     maxCache = adjusted;
                 }
@@ -483,7 +483,7 @@ public class ChunkRenderDispatcherLitematica
     private void uploadVertexBufferByBlockLayer(final ChunkSectionLayer layer, final ChunkRendererSchematicVbo renderChunk, final ChunkRenderDataSchematic compiledChunk, final VertexSorting sorter, boolean resortOnly, ProfilerFiller profiler)
             throws InterruptedException
     {
-        LOGGER.warn("[Dispatch] uploadVertexBufferByBlockLayer layer [{}]", layer.label());
+        LOGGER.debug("[Dispatch] uploadVertexBufferByBlockLayer layer [{}]", layer.label());
         profiler.push("upload_vbo_layer_"+layer.label());
         ByteBufferBuilder allocator = renderChunk.alloc(layer);
         final ChunkMeshDataSchematic chunkMeshData = compiledChunk.getMeshDataCache();
@@ -534,13 +534,13 @@ public class ChunkRenderDispatcherLitematica
 
             if (result != null)
             {
-                LOGGER.warn("[Dispatch] uploadVertexBufferByBlockLayer layer [{}] --> UPLOAD INDEX", layer.label());
+                LOGGER.debug("[Dispatch] uploadVertexBufferByBlockLayer layer [{}] --> UPLOAD INDEX", layer.label());
                 renderChunk.uploadIndexByBlockLayer(layer, result);
                 result.close();
             }
         }
 
-        LOGGER.warn("[Dispatch] uploadVertexBufferByBlockLayer layer [{}] --> DONE", layer.label());
+        LOGGER.debug("[Dispatch] uploadVertexBufferByBlockLayer layer [{}] --> DONE", layer.label());
 //        compiledChunk.updateMeshDataCache(chunkMeshData);
 //        renderChunk.updateChunkRenderData(compiledChunk);
         profiler.pop();
@@ -549,7 +549,7 @@ public class ChunkRenderDispatcherLitematica
     private void uploadVertexBufferByType(final OverlayRenderType type, final ChunkRendererSchematicVbo renderChunk, final ChunkRenderDataSchematic compiledChunk, final VertexSorting sorter, boolean resortOnly, ProfilerFiller profiler)
             throws InterruptedException
     {
-        LOGGER.warn("[Dispatch] uploadVertexBufferByType type [{}]", type.name());
+        LOGGER.debug("[Dispatch] uploadVertexBufferByType type [{}]", type.name());
         profiler.push("upload_vbo_overlay_"+type.name());
         ByteBufferBuilder allocator = renderChunk.alloc(type);
         final ChunkMeshDataSchematic chunkMeshData = compiledChunk.getMeshDataCache();
@@ -574,7 +574,7 @@ public class ChunkRenderDispatcherLitematica
 
         if (resortOnly == false)
         {
-            LOGGER.warn("[Dispatch] uploadVertexBufferByType type [{}] --> UPLOAD", type.name());
+            LOGGER.debug("[Dispatch] uploadVertexBufferByType type [{}] --> UPLOAD", type.name());
             renderChunk.uploadBuffersByType(type, meshData);
         }
 
@@ -606,7 +606,7 @@ public class ChunkRenderDispatcherLitematica
 //            }
 //        }
 
-        LOGGER.warn("[Dispatch] uploadVertexBufferByType type [{}] --> DONE", type.name());
+        LOGGER.debug("[Dispatch] uploadVertexBufferByType type [{}] --> DONE", type.name());
 //        compiledChunk.updateMeshDataCache(chunkMeshData);
 //        renderChunk.updateChunkRenderData(compiledChunk);
         profiler.pop();

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderTaskSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderTaskSchematic.java
@@ -62,7 +62,7 @@ public class ChunkRenderTaskSchematic implements Comparable<ChunkRenderTaskSchem
 
     protected void updateChunkRenderData(ChunkRenderDataSchematic data)
     {
-        LOGGER.warn("[Task] updateChunkRenderData() type: [{}]", this.type.name());
+        LOGGER.debug("[Task] updateChunkRenderData() type: [{}]", this.type.name());
         this.lock.lock();
 
         try
@@ -129,7 +129,7 @@ public class ChunkRenderTaskSchematic implements Comparable<ChunkRenderTaskSchem
 
     protected void finish()
     {
-        LOGGER.warn("[Task] finish() type: [{}]", this.type.name());
+        LOGGER.debug("[Task] finish() type: [{}]", this.type.name());
         this.lock.lock();
 
         try
@@ -155,7 +155,7 @@ public class ChunkRenderTaskSchematic implements Comparable<ChunkRenderTaskSchem
 
     protected void addFinishRunnable(Runnable runnable)
     {
-        LOGGER.warn("[Task] addFinishRunnable() type: [{}]", this.type.name());
+        LOGGER.debug("[Task] addFinishRunnable() type: [{}]", this.type.name());
         this.lock.lock();
 
         try

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderWorkerLitematica.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRenderWorkerLitematica.java
@@ -70,7 +70,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
         profiler.push("process_task");
         task.getLock().lock();
 
-        LOGGER.warn("[LW] processTask() task [{}] / [{}]", task.getType().name(), task.getStatus().name());
+        LOGGER.debug("[LW] processTask() task [{}] / [{}]", task.getType().name(), task.getStatus().name());
         try
         {
             if (task.getStatus() != ChunkRenderTaskSchematic.Status.PENDING)
@@ -110,7 +110,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
             profiler.popPush("run_task_now_" + taskType.name());
             if (taskType == ChunkRenderTaskSchematic.Type.REBUILD_CHUNK)
             {
-                LOGGER.warn("[LW] (REBUILD_CHUNK) --> [VBO]");
+                LOGGER.debug("[LW] (REBUILD_CHUNK) --> [VBO]");
                 task.getRenderChunk().rebuildChunk(task, profiler);
             }
 //            else if (taskType == ChunkRenderTaskSchematic.Type.UPLOAD_CHUNK)
@@ -120,7 +120,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
 //            }
             else if (taskType == ChunkRenderTaskSchematic.Type.RESORT_TRANSPARENCY)
             {
-                LOGGER.warn("[LW] (RESORT_TRANSPARENCY) --> [VBO]");
+                LOGGER.debug("[LW] (RESORT_TRANSPARENCY) --> [VBO]");
                 task.getRenderChunk().resortTransparency(task, profiler);
             }
 
@@ -160,7 +160,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
 
             if (taskType == ChunkRenderTaskSchematic.Type.REBUILD_CHUNK)
             {
-                LOGGER.warn("[LW] (REBUILD_CHUNK) --> Run Uploads");
+                LOGGER.debug("[LW] (REBUILD_CHUNK) --> Run Uploads");
 
                 //if (GuiBase.isCtrlDown()) System.out.printf("pre uploadChunk()\n");
                 for (ChunkSectionLayer layer : ChunkRenderLayers.BLOCK_RENDER_LAYERS)
@@ -185,7 +185,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
             }
             else if (taskType == ChunkRenderTaskSchematic.Type.RESORT_TRANSPARENCY)
             {
-                LOGGER.warn("[LW] (RESORT_TRANSPARENCY) --> Schedule Uploads");
+                LOGGER.debug("[LW] (RESORT_TRANSPARENCY) --> Schedule Uploads");
                 ChunkSectionLayer layer = ChunkSectionLayer.TRANSLUCENT;
 
                 if (compiledChunk.isBlockLayerEmpty(layer) == false)
@@ -207,7 +207,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
 //            compiledChunk.dumpRenderDataDebug();
 //            renderChunk.updateChunkRenderData(compiledChunk);
             profiler.popPush("run_task_later_" + taskType.name());
-            LOGGER.warn("[LW] (TASK_COMBINE) --> futuresList size [{}]", futuresList.size());
+            LOGGER.debug("[LW] (TASK_COMBINE) --> futuresList size [{}]", futuresList.size());
 
             final ListenableFuture<List<Object>> listenablefuture = Futures.allAsList(futuresList);
 
@@ -224,7 +224,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
             {
                 public void onSuccess(@Nullable List<Object> list)
                 {
-                    LOGGER.warn("[LW] procesTask() --> futureCallback onSuccess()");
+                    LOGGER.debug("[LW] procesTask() --> futureCallback onSuccess()");
 //                    ChunkRenderWorkerLitematica.this.clearUberBuffers(task);
                     task.getLock().lock();
 //                    final ChunkRenderDataSchematic chunkRenderData = task.getChunkRenderData();
@@ -252,7 +252,7 @@ public class ChunkRenderWorkerLitematica implements Runnable
                         return;
                     }
 
-                    LOGGER.warn("[LW] procesTask() --> futureCallback onSuccess() --> UPDATE");
+                    LOGGER.debug("[LW] procesTask() --> futureCallback onSuccess() --> UPDATE");
 //                    compiledChunk.dumpRenderDataDebug();
                     task.getRenderChunk().updateChunkRenderData(compiledChunk);
                 }

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
@@ -650,7 +650,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
     protected void rebuildChunk(ChunkRenderTaskSchematic task, ProfilerFiller profiler)
     {
-        LOGGER.warn("[VBO] rebuildChunk() pos [{}]", this.position.toShortString());
+        LOGGER.debug("[VBO] rebuildChunk() pos [{}]", this.position.toShortString());
         this.profiler = profiler;
         this.getProfiler().push("rebuild_chunk");
         ChunkRenderDataSchematic data = new ChunkRenderDataSchematic();
@@ -889,7 +889,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
             return;
         }
 
-        LOGGER.warn("[VBO] renderBlocksAndOverlay() pos [{}], stateSchematic: [{}]", pos.toShortString(), stateSchematic.toString());
+        LOGGER.debug("[VBO] renderBlocksAndOverlay() pos [{}], stateSchematic: [{}]", pos.toShortString(), stateSchematic.toString());
         this.getProfiler().push("render_build");
         this.overlayColor = null;
 
@@ -903,7 +903,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
             if (stateSchematic.hasBlockEntity())
             {
-                LOGGER.warn("[VBO] addBlockEntity - state [{}]", stateSchematic.toString());
+                LOGGER.debug("[VBO] addBlockEntity - state [{}]", stateSchematic.toString());
                 this.addBlockEntity(pos, chunkMeshData);
             }
 
@@ -1078,7 +1078,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                         else if (type.getRenderPriority() > typeAdj.getRenderPriority())
                         {
                             this.getProfiler().popPush("cull_render_default");
-                            LOGGER.warn("renderOverlay: Batched Block Side Quads [{}] -->", side.name());
+                            LOGGER.debug("renderOverlay: Batched Block Side Quads [{}] -->", side.name());
                             RenderUtils.drawBlockBoxSideBatchedQuads(relPos, side, this.overlayColor, 0, bufferOverlayQuads);
                         }
                         else { useDefault = true; }
@@ -1119,7 +1119,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 //                    LOGGER.warn("renderOverlay: Batched Default Quads B -->");
                     RenderUtils.drawBlockBoxBatchedQuads(relPos, this.overlayColor, 0, bufferOverlayQuads);
                 }
-                catch (Exception ignored) { }
+                catch (Exception e) { Litematica.LOGGER.error("Error rendering batched overlay quads", e); }
             }
 
             this.getProfiler().pop();
@@ -1242,7 +1242,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                     RenderUtils.drawBlockBoundingBoxOutlinesBatchedDebugLines(relPos, overlayColor, 0, lineWidth, bufferOverlayOutlines);
                 }
 
-                catch (Exception ignored) { }
+                catch (Exception e) { Litematica.LOGGER.error("Error rendering batched overlay outlines", e); }
             }
 
             this.getProfiler().pop();
@@ -1496,7 +1496,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
     protected void uploadBuffersByLayer(ChunkSectionLayer layer, @Nonnull MeshData meshData)
     {
-        LOGGER.warn("[VBO] uploadBuffersByLayer() Layer [{}], IndexCount [{}]", layer.label(), meshData.drawState().indexCount());
+        LOGGER.debug("[VBO] uploadBuffersByLayer() Layer [{}], IndexCount [{}]", layer.label(), meshData.drawState().indexCount());
         ChunkRenderBuffers gpuBuffers = this.getBuffersOrNull(layer);
         boolean useResorting = Configs.Visuals.RENDER_ENABLE_TRANSLUCENT_RESORTING.getBooleanValue();
 
@@ -1601,7 +1601,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
     protected void uploadBuffersByType(OverlayRenderType type, @Nonnull MeshData meshData)
     {
-        LOGGER.warn("[VBO] uploadBuffersByType() Overlay [{}], IndexCount [{}]", type.name(), meshData.drawState().indexCount());
+        LOGGER.debug("[VBO] uploadBuffersByType() Overlay [{}], IndexCount [{}]", type.name(), meshData.drawState().indexCount());
         ChunkRenderBuffers gpuBuffers = this.getBuffersOrNull(type);
 //        boolean useResorting = Configs.Visuals.SCHEMATIC_OVERLAY_ENABLE_RESORTING.getBooleanValue();
 
@@ -1707,7 +1707,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
     protected void uploadIndexByBlockLayer(ChunkSectionLayer layer, @Nonnull ByteBufferBuilder.Result buffer)
     {
-        LOGGER.warn("[VBO] uploadIndexByLayer() Layer [{}] --> BEGIN", layer.label());
+        LOGGER.debug("[VBO] uploadIndexByLayer() Layer [{}] --> BEGIN", layer.label());
         if (this.hasBuffers(layer))
         {
             ChunkRenderBuffers gpuBuffers = this.getBuffersOrNull(layer);
@@ -1740,7 +1740,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
     protected void uploadIndexByType(OverlayRenderType type, @Nonnull ByteBufferBuilder.Result buffer)
     {
-        LOGGER.warn("[VBO] uploadIndexByType() Overlay [{}] --> BEGIN", type.name());
+        LOGGER.debug("[VBO] uploadIndexByType() Overlay [{}] --> BEGIN", type.name());
         if (this.hasBuffers(type))
         {
             ChunkRenderBuffers gpuBuffers = this.getBuffersOrNull(type);
@@ -1776,7 +1776,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                                   @Nonnull ChunkMeshDataSchematic chunkMeshData)
             throws RuntimeException
     {
-        LOGGER.warn("[VBO] postRenderBlocks(): layer: [{}]", layer.label());
+        LOGGER.debug("[VBO] postRenderBlocks(): layer: [{}]", layer.label());
 
         if (!chunkRenderData.isBlockLayerEmpty(layer))
         {
@@ -1838,7 +1838,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                                    @Nonnull ChunkMeshDataSchematic chunkMeshData)
             throws RuntimeException
     {
-        LOGGER.warn("[VBO] postRenderOverlay(): overlay type: [{}]", type.name());
+        LOGGER.debug("[VBO] postRenderOverlay(): overlay type: [{}]", type.name());
 
         if (!chunkRenderData.isOverlayTypeEmpty(type))
         {
@@ -1914,7 +1914,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                                     @Nonnull ChunkMeshDataSchematic chunkMeshData)
             throws InterruptedException
     {
-        LOGGER.warn("[VBO] resortRenderBlocks() layer [{}]", layer.label());
+        LOGGER.debug("[VBO] resortRenderBlocks() layer [{}]", layer.label());
 
         if (!chunkRenderData.isBlockLayerEmpty(layer))
         {
@@ -1974,7 +1974,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                                      @Nonnull ChunkMeshDataSchematic chunkMeshData)
 //            throws InterruptedException
     {
-        LOGGER.warn("[VBO] resortRenderOverlay() overlay type [{}]", type.name());
+        LOGGER.debug("[VBO] resortRenderOverlay() overlay type [{}]", type.name());
 
         if (!chunkRenderData.isOverlayTypeEmpty(type))
         {
@@ -2031,7 +2031,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
     protected ChunkRenderTaskSchematic makeCompileTaskChunkSchematic(Supplier<Vec3> cameraPosSupplier)
     {
-        LOGGER.warn("[VBO] makeCompileTaskChunkSchematic()");
+        LOGGER.debug("[VBO] makeCompileTaskChunkSchematic()");
         /*  Threaded Code
 
         ChunkRenderTaskSchematic generator = new ChunkRenderTaskSchematic(this, ChunkRenderTaskSchematic.Type.REBUILD_CHUNK, cameraPosSupplier, this.getDistanceSq());
@@ -2063,7 +2063,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
     @Nullable
     protected ChunkRenderTaskSchematic makeCompileTaskTransparencySchematic(Supplier<Vec3> cameraPosSupplier)
     {
-        LOGGER.warn("[VBO] makeCompileTaskTransparencySchematic()");
+        LOGGER.debug("[VBO] makeCompileTaskTransparencySchematic()");
 
         /* Threaded Code
 

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
@@ -349,7 +349,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     {
         if (this.hasWorld())
         {
-            LOGGER.warn("[WorldRenderer] loadRenderers()");
+            LOGGER.debug("[WorldRenderer] loadRenderers()");
             if (profiler == null)
             {
                 profiler = Profiler.get();
@@ -399,7 +399,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
     protected void stopChunkUpdates(ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] stopChunkUpdates()");
+        LOGGER.debug("[WorldRenderer] stopChunkUpdates()");
         if (!this.chunksToUpdate.isEmpty())
         {
             this.chunksToUpdate.forEach(ChunkRendererSchematicVbo::deleteGlResources);
@@ -415,7 +415,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public void setupTerrain(Camera camera, Frustum frustum, int frameCount, boolean playerSpectator, ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] setupTerrain()");
+        LOGGER.debug("[WorldRenderer] setupTerrain()");
         this.profiler = profiler;
         profiler.push("setup_terrain");
 
@@ -499,7 +499,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
             //queuePositions.addAll(set);
 
             //if (GuiBase.isCtrlDown()) System.out.printf("sorted positions: %d\n", positions.size());
-            Litematica.LOGGER.warn("setupTerrain(): positions: {}", positions.size());
+            Litematica.LOGGER.debug("setupTerrain(): positions: {}", positions.size());
 
             profiler.popPush("update_iteration");
 
@@ -509,7 +509,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                 //SubChunkPos subChunk = queuePositions.poll();
                 int cx = chunkPos.x();
                 int cz = chunkPos.z();
-                LOGGER.warn("[WorldRenderer] setupTerrain() position[{}], chunkPos: {} // isLoaded: [{}]", count, chunkPos.toString(), this.world.getChunkSource().hasChunk(chunkPos.x(), chunkPos.z()));
+                LOGGER.debug("[WorldRenderer] setupTerrain() position[{}], chunkPos: {} // isLoaded: [{}]", count, chunkPos.toString(), this.world.getChunkSource().hasChunk(chunkPos.x(), chunkPos.z()));
                 // Only render sub-chunks that are within the client's render distance, and that
                 // have been already properly loaded on the client
                 if (Math.abs(cx - centerChunkX) <= renderDistance &&
@@ -556,13 +556,13 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
                 if (!chunkRendererTmp.needsImmediateUpdate() && !isNear)
                 {
-                    LOGGER.warn("[WorldRenderer] setupTerrain --> Update Later @ cp: {}", chunkRendererTmp.getChunkPos().toString());
+                    LOGGER.debug("[WorldRenderer] setupTerrain --> Update Later @ cp: {}", chunkRendererTmp.getChunkPos().toString());
                     this.chunksToUpdate.add(chunkRendererTmp);
                 }
                 else
                 {
                     //if (GuiBase.isCtrlDown()) System.out.printf("====== update now\n");
-                    LOGGER.warn("[WorldRenderer] setupTerrain --> Update Now @ cp: {}", chunkRendererTmp.getChunkPos().toString());
+                    LOGGER.debug("[WorldRenderer] setupTerrain --> Update Now @ cp: {}", chunkRendererTmp.getChunkPos().toString());
                     profiler.push("update_now");
                     this.profiler = profiler;
 
@@ -578,7 +578,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
         if (Reference.DEBUG_MODE && !this.chunksToUpdate.isEmpty())
         {
-            Litematica.LOGGER.warn("[WorldRenderer] setupTerrain // chunksToUpdate: {}", this.chunksToUpdate.size());
+            Litematica.LOGGER.debug("[WorldRenderer] setupTerrain // chunksToUpdate: {}", this.chunksToUpdate.size());
         }
 
 		this.clearWorldRenderStates();
@@ -590,7 +590,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public void updateChunks(long finishTimeNano, ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] updateChunks()");
+        LOGGER.debug("[WorldRenderer] updateChunks()");
         this.profiler = profiler;
         profiler.push("run_chunk_uploads");
         this.displayListEntitiesDirty |= this.renderDispatcher.runChunkUploads(finishTimeNano, profiler);
@@ -652,7 +652,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public void capturePreMainValues(CameraRenderState camera, GpuBufferSlice fogBuffer, ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] capturePreMainValues()");
+        LOGGER.debug("[WorldRenderer] capturePreMainValues()");
         this.vanillaFogBuffer = fogBuffer;
         this.profiler = profiler;
     }
@@ -662,7 +662,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                                        double cameraX, double cameraY, double cameraZ,
                                        ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] uploadRemainingBuffers()");
+        LOGGER.debug("[WorldRenderer] uploadRemainingBuffers()");
         this.profiler = profiler;
         if (RenderSystem.isOnRenderThread())
         {
@@ -677,7 +677,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                                    double cameraX, double cameraY, double cameraZ,
                                    ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] prepareBlockLayers()");
+        LOGGER.debug("[WorldRenderer] prepareBlockLayers()");
         this.profiler = profiler;
 //        RenderSystem.assertOnRenderThread();
         profiler.push("layer_multi_phase");
@@ -891,7 +891,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public void drawBlockLayerGroup(ChunkSectionLayerGroup group, @Nullable GpuSampler sampler)
     {
-        LOGGER.warn("[WorldRenderer] drawBlockLayerGroup() [{}]", group.label());
+        LOGGER.debug("[WorldRenderer] drawBlockLayerGroup() [{}]", group.label());
         if (this.schematicRenderState.hasBatchDraw() && this.shouldDraw)
         {
             this.profiler.push(Reference.MOD_ID + "_batch_draw_" + group.label());
@@ -946,7 +946,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public void scheduleTranslucentSorting(Vec3 cameraPos, ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] scheduleTranslucentSorting()");
+        LOGGER.debug("[WorldRenderer] scheduleTranslucentSorting()");
         double x = cameraPos.x();
         double y = cameraPos.y();
         double z = cameraPos.z();
@@ -977,7 +977,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public void renderBlockOverlays(Camera camera, float lineWidth, ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] renderBlockOverlays()");
+        LOGGER.debug("[WorldRenderer] renderBlockOverlays()");
         this.profiler = profiler;
         this.renderBlockOverlay(OverlayRenderType.OUTLINE, camera, lineWidth, profiler);
         this.renderBlockOverlay(OverlayRenderType.QUAD, camera, lineWidth, profiler);
@@ -985,7 +985,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
     protected void renderBlockOverlay(OverlayRenderType type, Camera camera, float lineWidth, ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] renderBlockOverlay() [{}]", type.name());
+        LOGGER.debug("[WorldRenderer] renderBlockOverlay() [{}]", type.name());
         profiler.push("overlay_" + type.name());
         this.profiler = profiler;
 
@@ -1052,7 +1052,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                 BlockStateModel model = this.getModelForState(state);
 
                 result = this.blockModelRenderer.tessellateBlock(world, state, pos, offset, model, state.getSeed(pos), output);
-                System.out.printf("renderBlock(): result [%s]\n", result);
+                LOGGER.trace("renderBlock(): result [{}]", result);
 
                 // TODO --> For testing the Vanilla Block Model Renderer
                 /*
@@ -1261,7 +1261,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public void prepareEntities(Camera camera, Frustum frustum, LevelRenderState renderStates, DeltaTracker tickCounter, ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] prepareEntities()");
+        LOGGER.debug("[WorldRenderer] prepareEntities()");
         this.profiler = profiler;
 
         if (this.renderEntitiesStartupCounter > 0)
@@ -1307,7 +1307,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                 ImmutableList<Entity> list = this.world.getEntitiesByChunk(chunkPos.x(), chunkPos.z(), fi.dy.masa.litematica.util.EntityUtils.NOT_PLAYER);
 
 //                LOGGER.error("[WorldRenderer] prepareEntities: Chunk: {}, EntityList [{}] // BB: [{}]", chunkPos.toString(), list.size(), bb.toString());
-//                LOGGER.warn("[WorldRenderer] prepareEntities: Chunk: [{}], TestList: [{}]", pos.toShortString(), list.size());
+//                LOGGER.debug("[WorldRenderer] prepareEntities: Chunk: [{}], TestList: [{}]", pos.toShortString(), list.size());
 
                 for (Entity entityTmp : list)
                 {
@@ -1322,7 +1322,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                     if ((this.renderedEntities.containsKey(entityTmp.position()) && this.renderedEntities.get(entityTmp.position()).equals(entityTmp.getUUID())) ||
                         !layerRange.isPositionWithinRange(MathUtils.floor(entityTmp.getX()), MathUtils.floor(entityTmp.getY()), MathUtils.floor(entityTmp.getZ())))
                     {
-//                        LOGGER.warn("[WorldRenderer] prepareEntities/iterate: Chunk: {}, Skipping POS / UUID [{}]", chunkPos.toString(), entityTmp.position(), entityTmp.getStringUUID());
+//                        LOGGER.debug("[WorldRenderer] prepareEntities/iterate: Chunk: {}, Skipping POS / UUID [{}]", chunkPos.toString(), entityTmp.position(), entityTmp.getStringUUID());
                         continue;
                     }
 
@@ -1352,7 +1352,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
                     if (shouldRender)
                     {
-//                        LOGGER.warn("[WorldRenderer] prepareEntities/shouldRender: Chunk: [{}], EntityPos [{}] // Adj. Pos: X [{}], Y [{}], Z [{}]",
+//                        LOGGER.debug("[WorldRenderer] prepareEntities/shouldRender: Chunk: [{}], EntityPos [{}] // Adj. Pos: X [{}], Y [{}], Z [{}]",
 //                                    pos.toShortString(), entityTmp.position().toString(),
 //                                    entityTmp.getX(), entityTmp.getY(), entityTmp.getZ());
 
@@ -1380,7 +1380,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                     }
                     else
                     {
-                        LOGGER.warn("Skipping Entity at pos X: [{}], Y: [{}], Z: [{}] (Should Render = False)", entityTmp.getX(), entityTmp.getY(), entityTmp.getZ());
+                        LOGGER.debug("Skipping Entity at pos X: [{}], Y: [{}], Z: [{}] (Should Render = False)", entityTmp.getX(), entityTmp.getY(), entityTmp.getZ());
                     }
                 }
             }
@@ -1392,7 +1392,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
 	public void renderEntities(Camera camera, Frustum frustum, PoseStack matrices, LevelRenderState renderStates, SubmitNodeCollector queue, ProfilerFiller profiler)
 	{
-        LOGGER.warn("[WorldRenderer] renderEntities()");
+        LOGGER.debug("[WorldRenderer] renderEntities()");
         if (this.schematicRenderState.entityStates.isEmpty())
         {
             return;
@@ -1419,7 +1419,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
 	public void prepareBlockEntities(Camera camera, Frustum frustum, LevelRenderState renderStates, PoseStack matrices, float tickProgress, ProfilerFiller profiler)
     {
-        LOGGER.warn("[WorldRenderer] prepareBlockEntities()");
+        LOGGER.debug("[WorldRenderer] prepareBlockEntities()");
         this.profiler = profiler;
         profiler.push("block_entities_prepare");
 
@@ -1440,7 +1440,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
             List<BlockEntity> tiles = chunkMeshData.getBlockEntities();
             List<BlockEntity> noCullTiles = chunkMeshData.getNoCullBlockEntities();
 
-            if (!tiles.isEmpty() && !noCullTiles.isEmpty())
+            if (!tiles.isEmpty() || !noCullTiles.isEmpty())
             {
 //                final BlockPos chunkOrigin = chunkRenderer.getOrigin();
                 final ChunkPos chunkPos = chunkRenderer.getChunkPos();
@@ -1538,7 +1538,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
 	public void renderBlockEntities(Camera camera, Frustum frustum, PoseStack matrices, LevelRenderState renderStates, SubmitNodeCollector queue, ProfilerFiller profiler)
 	{
-        LOGGER.warn("[WorldRenderer] renderBlockEntities()");
+        LOGGER.debug("[WorldRenderer] renderBlockEntities()");
         if (this.schematicRenderState.tileEntityStates.isEmpty())
         {
             return;
@@ -1569,7 +1569,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 //    @Override
 //    public void updateBlockEntities(Collection<BlockEntity> toRemove, Collection<BlockEntity> toAdd)
 //    {
-//        // LOGGER.warn("[WorldRenderer] updateBlockEntities()");
+//        // LOGGER.debug("[WorldRenderer] updateBlockEntities()");
 ////        int last = this.blockEntities.size();
 //
 //        synchronized (this.blockEntities)
@@ -1583,7 +1583,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public void scheduleChunkRenders(int chunkX, int chunkZ, boolean immediate)
     {
-         LOGGER.warn("[WorldRenderer] scheduleChunkRenders()");
+         LOGGER.debug("[WorldRenderer] scheduleChunkRenders()");
 //        this.getProfiler().push("schedule_render");
         if (Configs.Visuals.ENABLE_RENDERING.getBooleanValue() &&
             Configs.Visuals.ENABLE_SCHEMATIC_RENDERING.getBooleanValue())

--- a/src/main/java/fi/dy/masa/litematica/util/EasyPlaceUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/EasyPlaceUtils.java
@@ -95,10 +95,9 @@ public class EasyPlaceUtils
         {
             try
             {
-                // TODO FIXME cross-MC-version fragile
-                String name = Block.class.getSimpleName().equals("Block") ? "useWithoutItem": "a";
-                Method method = block.getClass().getMethod(name, BlockState.class, Level.class, BlockPos.class, Player.class, BlockHitResult.class);
-                Method baseMethod = Block.class.getMethod(name, BlockState.class, Level.class, BlockPos.class, Player.class, BlockHitResult.class);
+                // MC 26.1 is unobfuscated, method name is always useWithoutItem
+                Method method = block.getClass().getMethod("useWithoutItem", BlockState.class, Level.class, BlockPos.class, Player.class, BlockHitResult.class);
+                Method baseMethod = Block.class.getMethod("useWithoutItem", BlockState.class, Level.class, BlockPos.class, Player.class, BlockHitResult.class);
                 val = method.equals(baseMethod) == false;
             }
             catch (Exception e)

--- a/src/main/java/fi/dy/masa/litematica/util/PickBlockUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/PickBlockUtils.java
@@ -25,7 +25,6 @@ import fi.dy.masa.litematica.world.SchematicWorldHandler;
 @ApiStatus.Experimental
 public class PickBlockUtils
 {
-	// FIXME DO NOT USE
     @Nullable
     public static InteractionHand doPickBlockForStack(ItemStack stack)
     {
@@ -35,18 +34,13 @@ public class PickBlockUtils
         {
             return null;
         }
-//        boolean ignoreNbt = Configs.Generic.PICK_BLOCK_IGNORE_NBT.getBooleanValue();
         boolean ignoreNbt = false;
         InteractionHand hand = EntityUtils.getUsedHandForItem(player, stack, ignoreNbt);
 
         if (stack.isEmpty() == false && hand == null)
         {
-            //switchItemToHand(stack, ignoreNbt);
-            //hand = EntityWrap.getUsedHandForItem(player, stack, ignoreNbt);
-
-//            fi.dy.masa.malilib.util.InventoryUtils.swapItemToMainHand(stack, mc);
-//            hand = Hand.MAIN_HAND;
-			return null;
+            fi.dy.masa.malilib.util.InventoryUtils.swapItemToMainHand(stack, mc);
+            hand = InteractionHand.MAIN_HAND;
         }
 
         if (hand != null)
@@ -57,8 +51,7 @@ public class PickBlockUtils
         return hand;
     }
 
-    // FIXME DO NOT USE
-	@Nullable
+    @Nullable
     public static InteractionHand pickBlockLast()
     {
         Minecraft mc = Minecraft.getInstance();
@@ -90,7 +83,6 @@ public class PickBlockUtils
         return null;
     }
 
-	// FIXME DO NOT USE
     @Nullable
     private static InteractionHand doPickBlockForPosition(BlockPos pos)
     {
@@ -108,9 +100,7 @@ public class PickBlockUtils
             return null;
         }
         BlockState state = world.getBlockState(pos);
-//        ItemStack stack = MaterialCache.getInstance().getRequiredBuildItemForState(state, world, pos);
-        ItemStack stack = state.getBlock().asItem().getDefaultInstance();
-//        boolean ignoreNbt = Configs.Generic.PICK_BLOCK_IGNORE_NBT.getBooleanValue();
+        ItemStack stack = fi.dy.masa.litematica.materials.MaterialCache.getInstance().getRequiredBuildItemForState(state, world, pos);
         boolean ignoreNbt = false;
 
         if (stack.isEmpty() == false)


### PR DESCRIPTION
## Summary

- **Convert 40+ `LOGGER.warn` debug stubs to `LOGGER.debug`** across the render pipeline (WorldRendererSchematic, ChunkRendererSchematicVbo, ChunkMeshDataSchematic, ChunkRenderDispatcherLitematica, ChunkRenderWorkerLitematica, ChunkRenderTaskSchematic, ChunkRenderDataSchematic) — prevents log flooding during normal rendering
- **Replace silent `catch(Exception ignored){}` with proper error logging** in OverlayRenderer, ByteBufferBuilderCache, ChunkMeshCache, ChunkRenderBatchDraw, ChunkRenderDispatcherLitematica, ChunkRendererSchematicVbo — errors are now visible in logs instead of being silently swallowed
- **Fix block entity rendering bug**: `prepareBlockEntities()` used `&&` instead of `||` when checking tile entity lists, causing block entities to not render when only one of the two lists (culled/no-cull) was non-empty
- **Implement `RenderHandler.onExtractWorldLast()`** — was an empty TODO stub, now calls `uploadRemainingBuffers` during the extract phase
- **Fix PickBlockUtils**: Enable item swapping via `malilib.InventoryUtils.swapItemToMainHand()` and use `MaterialCache.getRequiredBuildItemForState()` instead of `getDefaultInstance()` — previously returned null and was marked "DO NOT USE"
- **Fix EasyPlaceUtils**: Remove fragile obfuscation detection for `useWithoutItem` method — MC 26.1 is unobfuscated so the method name is always `useWithoutItem`
- **Convert `System.out.printf` debug output** to `LOGGER.trace`

## Test plan

- [x] Mod compiles cleanly with `./gradlew build`
- [x] Ghost block rendering works (solid blocks, translucent)
- [x] Block entity rendering verified (chests, signs)
- [x] Overlay rendering works (missing/wrong/extra block highlights)
- [x] No log flooding during normal schematic rendering
- [ ] Easy Place mode functional testing
- [ ] Material list generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)