### PR TITLE
Port Litematica to minecraft 26.2-snapshot-5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 repositories {
+	mavenLocal()
 	maven { url = "https://masa.dy.fi/maven/sakura-ryoko"
 		content {includeGroupAndSubgroups("fi.dy.masa")}
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,11 +12,11 @@ mod_file_name = litematica-fabric
 mod_version = 0.27.2
 
 # Required malilib version
-malilib_version = 0.28.3
+malilib_version = 0.28.3+26.2-snapshot-5
 
 # Minecraft, Fabric Loader and API and mappings versions
-minecraft_version_out = 26.1.2
-minecraft_version = 26.1.2
+minecraft_version_out = 26.2-snapshot-5
+minecraft_version = 26.2-snapshot-5
 
 fabric_loader_version = 0.19.2
 mod_menu_version = 18.0.0-alpha.8

--- a/src/main/java/fi/dy/masa/litematica/command/PmCommand.java
+++ b/src/main/java/fi/dy/masa/litematica/command/PmCommand.java
@@ -28,7 +28,7 @@ public class PmCommand implements IClientCommandListener
 		if (mc.getCameraEntity() == null) return false;
 		List<String> list = new ArrayList<>(args);      // Copy it first
 		ChunkPos camPos = mc.getCameraEntity().chunkPosition();
-		ChatComponent chat = mc.gui.getChat();
+		ChatComponent chat = mc.gui.hud.getChat();
 		list.removeFirst();
 
 		if (!list.isEmpty())

--- a/src/main/java/fi/dy/masa/litematica/compat/iris/IrisRenderingFix.java
+++ b/src/main/java/fi/dy/masa/litematica/compat/iris/IrisRenderingFix.java
@@ -50,7 +50,7 @@ public class IrisRenderingFix
 
 	private LevelRenderState levelRenderState()
 	{
-		return this.mc.gameRenderer.getGameRenderState().levelRenderState;
+		return this.mc.gameRenderer.gameRenderState().levelRenderState;
 	}
 
 	private DeltaTracker deltaTracker()

--- a/src/main/java/fi/dy/masa/litematica/data/CachedTagManager.java
+++ b/src/main/java/fi/dy/masa/litematica/data/CachedTagManager.java
@@ -6,6 +6,8 @@ import fi.dy.masa.malilib.data.CachedTagKey;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 
 /**
@@ -53,24 +55,14 @@ public class CachedTagManager
 	{
 		List<String> list = new ArrayList<>();
 
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLACK_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLUE_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BROWN_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.CYAN_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GRAY_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GREEN_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_BLUE_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_GRAY_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIME_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.MAGENTA_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.ORANGE_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PINK_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PURPLE_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.RED_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.YELLOW_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.WHITE_STAINED_GLASS).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.TINTED_GLASS).toString());
+		list.add("minecraft:glass");
+
+		for (DyeColor color : DyeColor.VALUES)
+		{
+			list.add("minecraft:" + color.getName() + "_stained_glass");
+		}
+
+		list.add("minecraft:tinted_glass");
 
 		return list;
 	}
@@ -79,23 +71,12 @@ public class CachedTagManager
 	{
 		List<String> list = new ArrayList<>();
 
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLACK_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLUE_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BROWN_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.CYAN_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GRAY_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GREEN_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_BLUE_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_GRAY_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIME_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.MAGENTA_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.ORANGE_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PINK_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PURPLE_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.RED_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.YELLOW_STAINED_GLASS_PANE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.WHITE_STAINED_GLASS_PANE).toString());
+		list.add("minecraft:glass_pane");
+
+		for (DyeColor color : DyeColor.VALUES)
+		{
+			list.add("minecraft:" + color.getName() + "_stained_glass_pane");
+		}
 
 		return list;
 	}
@@ -103,23 +84,7 @@ public class CachedTagManager
 	private static List<String> buildConcretePowderItemCache()
 	{
 		List<String> list = new ArrayList<>();
-
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLACK_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLUE_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BROWN_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.CYAN_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GRAY_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GREEN_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_BLUE_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_GRAY_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIME_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.MAGENTA_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.ORANGE_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PINK_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PURPLE_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.RED_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.YELLOW_CONCRETE_POWDER).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.WHITE_CONCRETE_POWDER).toString());
+		list.add("#minecraft:concrete_powders");
 
 		return list;
 	}
@@ -127,23 +92,7 @@ public class CachedTagManager
 	private static List<String> buildConcreteItemCache()
 	{
 		List<String> list = new ArrayList<>();
-
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLACK_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLUE_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BROWN_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.CYAN_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GRAY_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GREEN_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_BLUE_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_GRAY_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIME_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.MAGENTA_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.ORANGE_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PINK_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PURPLE_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.RED_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.YELLOW_CONCRETE).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.WHITE_CONCRETE).toString());
+		list.add("#minecraft:concrete");
 
 		return list;
 	}
@@ -151,23 +100,7 @@ public class CachedTagManager
 	private static List<String> buildGlazedTerracottaItemCache()
 	{
 		List<String> list = new ArrayList<>();
-
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLACK_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BLUE_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.BROWN_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.CYAN_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GRAY_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.GREEN_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_BLUE_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIGHT_GRAY_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.LIME_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.MAGENTA_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.ORANGE_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PINK_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.PURPLE_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.RED_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.YELLOW_GLAZED_TERRACOTTA).toString());
-		list.add(BuiltInRegistries.ITEM.getKey(Items.WHITE_GLAZED_TERRACOTTA).toString());
+		list.add("#minecraft:glazed_terracotta");
 
 		return list;
 	}
@@ -175,26 +108,26 @@ public class CachedTagManager
     {
         List<String> list = new ArrayList<>();
 
-        list.add(BuiltInRegistries.ITEM.getKey(Items.BONE_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.CLAY).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.COAL_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.COPPER_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.DIAMOND_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.EMERALD_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.GOLD_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.HAY_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.HONEY_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.IRON_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.LAPIS_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.MELON).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.NETHERITE_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.RAW_COPPER_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.RAW_GOLD_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.RAW_IRON_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.REDSTONE_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.RESIN_BLOCK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.RESIN_BRICKS).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.SLIME_BLOCK).toString());
+        list.add(itemId(Items.BONE_BLOCK));
+        list.add(itemId(Items.CLAY));
+        list.add(itemId(Items.COAL_BLOCK));
+        list.add(itemId(Items.COPPER_BLOCK.weathering().unaffected()));
+        list.add(itemId(Items.DIAMOND_BLOCK));
+        list.add(itemId(Items.EMERALD_BLOCK));
+        list.add(itemId(Items.GOLD_BLOCK));
+        list.add(itemId(Items.HAY_BLOCK));
+        list.add(itemId(Items.HONEY_BLOCK));
+        list.add(itemId(Items.IRON_BLOCK));
+        list.add(itemId(Items.LAPIS_BLOCK));
+        list.add(itemId(Items.MELON));
+        list.add(itemId(Items.NETHERITE_BLOCK));
+        list.add(itemId(Items.RAW_COPPER_BLOCK));
+        list.add(itemId(Items.RAW_GOLD_BLOCK));
+        list.add(itemId(Items.RAW_IRON_BLOCK));
+        list.add(itemId(Items.REDSTONE_BLOCK));
+        list.add(itemId(Items.RESIN_BLOCK));
+        list.add(itemId(Items.RESIN_BRICKS));
+        list.add(itemId(Items.SLIME_BLOCK));
 
         return list;
     }
@@ -203,29 +136,29 @@ public class CachedTagManager
     {
         List<String> list = new ArrayList<>();
 
-        list.add(BuiltInRegistries.ITEM.getKey(Items.BONE).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.CLAY_BALL).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.COAL).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.COPPER_INGOT).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.DIAMOND).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.EMERALD).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.GLOWSTONE_DUST).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.GOLD_INGOT).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.GOLD_NUGGET).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.HONEY_BOTTLE).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.ICE).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.IRON_INGOT).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.IRON_NUGGET).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.LAPIS_LAZULI).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.MELON_SLICE).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.NETHERITE_INGOT).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.NETHER_WART).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.PACKED_ICE).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.REDSTONE).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.RESIN_BRICK).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.RESIN_CLUMP).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.SLIME_BALL).toString());
-        list.add(BuiltInRegistries.ITEM.getKey(Items.WHEAT).toString());
+        list.add(itemId(Items.BONE));
+        list.add(itemId(Items.CLAY_BALL));
+        list.add(itemId(Items.COAL));
+        list.add(itemId(Items.COPPER_INGOT));
+        list.add(itemId(Items.DIAMOND));
+        list.add(itemId(Items.EMERALD));
+        list.add(itemId(Items.GLOWSTONE_DUST));
+        list.add(itemId(Items.GOLD_INGOT));
+        list.add(itemId(Items.GOLD_NUGGET));
+        list.add(itemId(Items.HONEY_BOTTLE));
+        list.add(itemId(Items.ICE));
+        list.add(itemId(Items.IRON_INGOT));
+        list.add(itemId(Items.IRON_NUGGET));
+        list.add(itemId(Items.LAPIS_LAZULI));
+        list.add(itemId(Items.MELON_SLICE));
+        list.add(itemId(Items.NETHERITE_INGOT));
+        list.add(itemId(Items.NETHER_WART));
+        list.add(itemId(Items.PACKED_ICE));
+        list.add(itemId(Items.REDSTONE));
+        list.add(itemId(Items.RESIN_BRICK));
+        list.add(itemId(Items.RESIN_CLUMP));
+        list.add(itemId(Items.SLIME_BALL));
+        list.add(itemId(Items.WHEAT));
 
         return list;
     }
@@ -240,4 +173,9 @@ public class CachedTagManager
 		CachedItemTags.getInstance().clearEntry(PACKED_BLOCK_ITEMS_KEY);
 		CachedItemTags.getInstance().clearEntry(UNPACKED_BLOCK_ITEMS_KEY);
     }
+
+	private static String itemId(Item item)
+	{
+		return BuiltInRegistries.ITEM.getKey(item).toString();
+	}
 }

--- a/src/main/java/fi/dy/masa/litematica/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/event/RenderHandler.java
@@ -81,7 +81,7 @@ public class RenderHandler implements IRenderer
 
             if (GuiUtils.getCurrentScreen() == null)
             {
-                if (ctx.mc().options.hideGui == false)
+                if (ctx.mc().gui.hud.isHidden() == false)
                 {
                     ToolHud.getInstance().renderHud(ctx);
                     profiler.popPush("overlay_hover_info");

--- a/src/main/java/fi/dy/masa/litematica/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/event/RenderHandler.java
@@ -59,7 +59,7 @@ public class RenderHandler implements IRenderer
 
             // Schematic Overlay Rendering
             profiler.popPush("schematic_overlay");
-            LitematicaRenderer.getInstance().piecewiseRenderOverlay(profiler);
+            LitematicaRenderer.getInstance().piecewiseRenderOverlay(fb, profiler);
             profiler.pop();
         }
     }

--- a/src/main/java/fi/dy/masa/litematica/gui/GuiSchematicManager.java
+++ b/src/main/java/fi/dy/masa/litematica/gui/GuiSchematicManager.java
@@ -522,7 +522,7 @@ public class GuiSchematicManager extends GuiSchematicBrowserBase implements ISel
 				try
 				{
 					Minecraft mc = Minecraft.getInstance();
-					Screenshot.takeScreenshot(mc.getMainRenderTarget(), (screenshot) ->
+					Screenshot.takeScreenshot(mc.gameRenderer.mainRenderTarget(), (screenshot) ->
 					{
 						int x = screenshot.getWidth() >= screenshot.getHeight()
 								? (screenshot.getWidth() - screenshot.getHeight()) / 2 : 0;

--- a/src/main/java/fi/dy/masa/litematica/materials/json/MaterialListJsonOverrides.java
+++ b/src/main/java/fi/dy/masa/litematica/materials/json/MaterialListJsonOverrides.java
@@ -6,9 +6,11 @@ import java.util.Set;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.level.block.WeatheringCopperCollection;
 import fi.dy.masa.malilib.data.CachedTagUtils;
 import org.apache.commons.lang3.math.Fraction;
 import org.apache.commons.lang3.tuple.Pair;
@@ -32,71 +34,30 @@ public class MaterialListJsonOverrides
         return BuiltInRegistries.ITEM.wrapAsHolder(item);
     }
 
+    private void addCopperOverrides(WeatheringCopperCollection<Item> collection)
+    {
+        Holder<Item> unwaxedBase = this.add(collection.weathering().unaffected());
+        this.overrides.add(new ResultOverride(this.add(collection.weathering().exposed()), unwaxedBase, Fraction.ONE));
+        this.overrides.add(new ResultOverride(this.add(collection.weathering().weathered()), unwaxedBase, Fraction.ONE));
+        this.overrides.add(new ResultOverride(this.add(collection.weathering().oxidized()), unwaxedBase, Fraction.ONE));
+
+        Holder<Item> waxedBase = this.add(collection.waxed().unaffected());
+        this.overrides.add(new ResultOverride(this.add(collection.waxed().exposed()), waxedBase, Fraction.ONE));
+        this.overrides.add(new ResultOverride(this.add(collection.waxed().weathered()), waxedBase, Fraction.ONE));
+        this.overrides.add(new ResultOverride(this.add(collection.waxed().oxidized()), waxedBase, Fraction.ONE));
+    }
+
     private void initOverrides()
     {
-        // Copper Block
-        this.overrides.add(new ResultOverride(this.add(Items.EXPOSED_COPPER),         this.add(Items.COPPER_BLOCK), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WEATHERED_COPPER),       this.add(Items.COPPER_BLOCK), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.OXIDIZED_COPPER),        this.add(Items.COPPER_BLOCK), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_EXPOSED_COPPER),   this.add(Items.WAXED_COPPER_BLOCK), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_WEATHERED_COPPER), this.add(Items.WAXED_COPPER_BLOCK), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_OXIDIZED_COPPER),  this.add(Items.WAXED_COPPER_BLOCK), Fraction.ONE));
-        // Copper Grate
-        this.overrides.add(new ResultOverride(this.add(Items.EXPOSED_COPPER_GRATE),         this.add(Items.COPPER_GRATE), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WEATHERED_COPPER_GRATE),       this.add(Items.COPPER_GRATE), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.OXIDIZED_COPPER_GRATE),        this.add(Items.COPPER_GRATE), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_EXPOSED_COPPER_GRATE),   this.add(Items.WAXED_COPPER_GRATE), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_WEATHERED_COPPER_GRATE), this.add(Items.WAXED_COPPER_GRATE), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_OXIDIZED_COPPER_GRATE),  this.add(Items.WAXED_COPPER_GRATE), Fraction.ONE));
-        // Cut Copper
-        this.overrides.add(new ResultOverride(this.add(Items.EXPOSED_CUT_COPPER),         this.add(Items.CUT_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WEATHERED_CUT_COPPER),       this.add(Items.CUT_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.OXIDIZED_CUT_COPPER),        this.add(Items.CUT_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_EXPOSED_CUT_COPPER),   this.add(Items.WAXED_CUT_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_WEATHERED_CUT_COPPER), this.add(Items.WAXED_CUT_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_OXIDIZED_CUT_COPPER),  this.add(Items.WAXED_CUT_COPPER), Fraction.ONE));
-        // Chiseled Copper
-        this.overrides.add(new ResultOverride(this.add(Items.EXPOSED_CHISELED_COPPER),         this.add(Items.CHISELED_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WEATHERED_CHISELED_COPPER),       this.add(Items.CHISELED_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.OXIDIZED_CHISELED_COPPER),        this.add(Items.CHISELED_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_EXPOSED_CHISELED_COPPER),   this.add(Items.WAXED_CHISELED_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_WEATHERED_CHISELED_COPPER), this.add(Items.WAXED_CHISELED_COPPER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_OXIDIZED_CHISELED_COPPER),  this.add(Items.WAXED_CHISELED_COPPER), Fraction.ONE));
-        // Copper Bulb
-        this.overrides.add(new ResultOverride(this.add(Items.EXPOSED_COPPER_BULB),         this.add(Items.COPPER_BULB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WEATHERED_COPPER_BULB),       this.add(Items.COPPER_BULB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.OXIDIZED_COPPER_BULB),        this.add(Items.COPPER_BULB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_EXPOSED_COPPER_BULB),   this.add(Items.WAXED_COPPER_BULB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_WEATHERED_COPPER_BULB), this.add(Items.WAXED_COPPER_BULB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_OXIDIZED_COPPER_BULB),  this.add(Items.WAXED_COPPER_BULB), Fraction.ONE));
-        // Copper Slab
-        this.overrides.add(new ResultOverride(this.add(Items.EXPOSED_CUT_COPPER_SLAB),         this.add(Items.CUT_COPPER_SLAB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WEATHERED_CUT_COPPER_SLAB),       this.add(Items.CUT_COPPER_SLAB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.OXIDIZED_CUT_COPPER_SLAB),        this.add(Items.CUT_COPPER_SLAB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_EXPOSED_CUT_COPPER_SLAB),   this.add(Items.WAXED_CUT_COPPER_SLAB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_WEATHERED_CUT_COPPER_SLAB), this.add(Items.WAXED_CUT_COPPER_SLAB), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_OXIDIZED_CUT_COPPER_SLAB),  this.add(Items.WAXED_CUT_COPPER_SLAB), Fraction.ONE));
-        // Copper Stairs
-        this.overrides.add(new ResultOverride(this.add(Items.EXPOSED_CUT_COPPER_STAIRS),         this.add(Items.CUT_COPPER_STAIRS), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WEATHERED_CUT_COPPER_STAIRS),       this.add(Items.CUT_COPPER_STAIRS), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.OXIDIZED_CUT_COPPER_STAIRS),        this.add(Items.CUT_COPPER_STAIRS), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_EXPOSED_CUT_COPPER_STAIRS),   this.add(Items.WAXED_CUT_COPPER_STAIRS), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_WEATHERED_CUT_COPPER_STAIRS), this.add(Items.WAXED_CUT_COPPER_STAIRS), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_OXIDIZED_CUT_COPPER_STAIRS),  this.add(Items.WAXED_CUT_COPPER_STAIRS), Fraction.ONE));
-        // Copper Door
-        this.overrides.add(new ResultOverride(this.add(Items.EXPOSED_COPPER_DOOR),         this.add(Items.COPPER_DOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WEATHERED_COPPER_DOOR),       this.add(Items.COPPER_DOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.OXIDIZED_COPPER_DOOR),        this.add(Items.COPPER_DOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_EXPOSED_COPPER_DOOR),   this.add(Items.WAXED_COPPER_DOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_WEATHERED_COPPER_DOOR), this.add(Items.WAXED_COPPER_DOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_OXIDIZED_COPPER_DOOR),  this.add(Items.WAXED_COPPER_DOOR), Fraction.ONE));
-        // Copper Trap Door
-        this.overrides.add(new ResultOverride(this.add(Items.EXPOSED_COPPER_TRAPDOOR),         this.add(Items.COPPER_TRAPDOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WEATHERED_COPPER_TRAPDOOR),       this.add(Items.COPPER_TRAPDOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.OXIDIZED_COPPER_TRAPDOOR),        this.add(Items.COPPER_TRAPDOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_EXPOSED_COPPER_TRAPDOOR),   this.add(Items.WAXED_COPPER_TRAPDOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_WEATHERED_COPPER_TRAPDOOR), this.add(Items.WAXED_COPPER_TRAPDOOR), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WAXED_OXIDIZED_COPPER_TRAPDOOR),  this.add(Items.WAXED_COPPER_TRAPDOOR), Fraction.ONE));
+        this.addCopperOverrides(Items.COPPER_BLOCK);
+        this.addCopperOverrides(Items.COPPER_GRATE);
+        this.addCopperOverrides(Items.CUT_COPPER);
+        this.addCopperOverrides(Items.CHISELED_COPPER);
+        this.addCopperOverrides(Items.COPPER_BULB);
+        this.addCopperOverrides(Items.CUT_COPPER_SLAB);
+        this.addCopperOverrides(Items.CUT_COPPER_STAIRS);
+        this.addCopperOverrides(Items.COPPER_DOOR);
+        this.addCopperOverrides(Items.COPPER_TRAPDOOR);
         // Stripped Woods
         this.overrides.add(new ResultOverride(this.add(Items.STRIPPED_ACACIA_LOG),   this.add(Items.ACACIA_LOG), Fraction.ONE));
         this.overrides.add(new ResultOverride(this.add(Items.STRIPPED_BAMBOO_BLOCK), this.add(Items.BAMBOO), Fraction.ONE));
@@ -111,22 +72,10 @@ public class MaterialListJsonOverrides
         this.overrides.add(new ResultOverride(this.add(Items.STRIPPED_SPRUCE_LOG),   this.add(Items.SPRUCE_LOG), Fraction.ONE));
         this.overrides.add(new ResultOverride(this.add(Items.STRIPPED_WARPED_STEM),  this.add(Items.WARPED_STEM), Fraction.ONE));
         // Concrete
-        this.overrides.add(new ResultOverride(this.add(Items.BLACK_CONCRETE),       this.add(Items.BLACK_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.BLUE_CONCRETE),        this.add(Items.BLUE_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.BROWN_CONCRETE),       this.add(Items.BROWN_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.CYAN_CONCRETE),        this.add(Items.CYAN_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.GRAY_CONCRETE),        this.add(Items.GRAY_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.GREEN_CONCRETE),       this.add(Items.GREEN_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.LIGHT_BLUE_CONCRETE),  this.add(Items.LIGHT_BLUE_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.LIGHT_GRAY_CONCRETE),  this.add(Items.LIGHT_GRAY_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.LIME_CONCRETE),        this.add(Items.LIME_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.MAGENTA_CONCRETE),     this.add(Items.MAGENTA_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.ORANGE_CONCRETE),      this.add(Items.ORANGE_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.PINK_CONCRETE),        this.add(Items.PINK_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.PURPLE_CONCRETE),      this.add(Items.PURPLE_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.RED_CONCRETE),         this.add(Items.RED_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.YELLOW_CONCRETE),      this.add(Items.YELLOW_CONCRETE_POWDER), Fraction.ONE));
-        this.overrides.add(new ResultOverride(this.add(Items.WHITE_CONCRETE),       this.add(Items.WHITE_CONCRETE_POWDER), Fraction.ONE));
+        for (DyeColor color : DyeColor.VALUES)
+        {
+            this.overrides.add(new ResultOverride(this.add(Items.CONCRETE.pick(color)), this.add(Items.CONCRETE_POWDER.pick(color)), Fraction.ONE));
+        }
         // Anvils
         this.overrides.add(new ResultOverride(this.add(Items.CHIPPED_ANVIL), this.add(Items.ANVIL), Fraction.ONE));
         this.overrides.add(new ResultOverride(this.add(Items.DAMAGED_ANVIL), this.add(Items.ANVIL), Fraction.ONE));
@@ -142,7 +91,7 @@ public class MaterialListJsonOverrides
         // x9 = x1
         this.packingOverrides.add(new ResultOverride(this.add(Items.BONE_MEAL), this.add(Items.BONE_BLOCK), by9));
         this.packingOverrides.add(new ResultOverride(this.add(Items.COAL), this.add(Items.COAL_BLOCK), by9));
-        this.packingOverrides.add(new ResultOverride(this.add(Items.COPPER_INGOT), this.add(Items.COPPER_BLOCK), by9));
+        this.packingOverrides.add(new ResultOverride(this.add(Items.COPPER_INGOT), this.add(Items.COPPER_BLOCK.weathering().unaffected()), by9));
         this.packingOverrides.add(new ResultOverride(this.add(Items.DIAMOND), this.add(Items.DIAMOND_BLOCK), by9));
         this.packingOverrides.add(new ResultOverride(this.add(Items.EMERALD), this.add(Items.EMERALD_BLOCK), by9));
         this.packingOverrides.add(new ResultOverride(this.add(Items.GOLD_INGOT), this.add(Items.GOLD_BLOCK), by9));
@@ -190,15 +139,15 @@ public class MaterialListJsonOverrides
     {
         if (firstItem.is(ItemTags.WOOL))
         {
-            return BuiltInRegistries.ITEM.wrapAsHolder(Items.WHITE_WOOL);
+            return BuiltInRegistries.ITEM.wrapAsHolder(Items.WOOL.white());
         }
         else if (firstItem.is(ItemTags.WOOL_CARPETS))
         {
-            return BuiltInRegistries.ITEM.wrapAsHolder(Items.WHITE_CARPET);
+            return BuiltInRegistries.ITEM.wrapAsHolder(Items.CARPET.white());
         }
         else if (firstItem.is(ItemTags.BEDS))
         {
-            return BuiltInRegistries.ITEM.wrapAsHolder(Items.WHITE_BED);
+            return BuiltInRegistries.ITEM.wrapAsHolder(Items.BED.white());
         }
         else if (firstItem.is(ItemTags.CANDLES))
         {
@@ -210,7 +159,7 @@ public class MaterialListJsonOverrides
         }
         else if (firstItem.is(ItemTags.BANNERS))
         {
-            return BuiltInRegistries.ITEM.wrapAsHolder(Items.WHITE_BANNER);
+            return BuiltInRegistries.ITEM.wrapAsHolder(Items.BANNER.white());
         }
         else if (firstItem.is(ItemTags.TERRACOTTA))
         {
@@ -222,7 +171,7 @@ public class MaterialListJsonOverrides
         }
         else if (firstItem.is(ItemTags.HARNESSES))
         {
-            return BuiltInRegistries.ITEM.wrapAsHolder(Items.WHITE_HARNESS);
+            return BuiltInRegistries.ITEM.wrapAsHolder(Items.HARNESS.white());
         }
         else if (CachedTagUtils.matchItemTag(CachedTagManager.GLASS_ITEMS_KEY, firstItem))
         {
@@ -234,15 +183,15 @@ public class MaterialListJsonOverrides
         }
         else if (CachedTagUtils.matchItemTag(CachedTagManager.CONCRETE_POWDER_ITEMS_KEY, firstItem))
         {
-            return BuiltInRegistries.ITEM.wrapAsHolder(Items.WHITE_CONCRETE_POWDER);
+            return BuiltInRegistries.ITEM.wrapAsHolder(Items.CONCRETE_POWDER.white());
         }
         else if (CachedTagUtils.matchItemTag(CachedTagManager.CONCRETE_ITEMS_KEY, firstItem))
         {
-            return BuiltInRegistries.ITEM.wrapAsHolder(Items.WHITE_CONCRETE);
+            return BuiltInRegistries.ITEM.wrapAsHolder(Items.CONCRETE.white());
         }
         else if (CachedTagUtils.matchItemTag(CachedTagManager.GLAZED_TERRACOTTA_ITEMS_KEY, firstItem))
         {
-            return BuiltInRegistries.ITEM.wrapAsHolder(Items.WHITE_GLAZED_TERRACOTTA);
+            return BuiltInRegistries.ITEM.wrapAsHolder(Items.GLAZED_TERRACOTTA.white());
         }
 
         return this.matchOverride(firstItem, 1).getLeft();
@@ -255,96 +204,96 @@ public class MaterialListJsonOverrides
         {
             if (input.is(ItemTags.BEDS))
             {
-                if (ing.test(Items.WHITE_BED.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_BED.getDefaultInstance()))
+                if (ing.test(Items.BED.white().getDefaultInstance()) ||
+                    ing.test(Items.BED.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (input.is(ItemTags.WOOL))
             {
-                if (ing.test(Items.WHITE_WOOL.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_WOOL.getDefaultInstance()))
+                if (ing.test(Items.WOOL.white().getDefaultInstance()) ||
+                    ing.test(Items.WOOL.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (input.is(ItemTags.WOOL_CARPETS))
             {
-                if (ing.test(Items.WHITE_CARPET.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_CARPET.getDefaultInstance()))
+                if (ing.test(Items.CARPET.white().getDefaultInstance()) ||
+                    ing.test(Items.CARPET.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (input.is(ItemTags.CANDLES))
             {
-                if (ing.test(Items.WHITE_CANDLE.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_CANDLE.getDefaultInstance()))
+                if (ing.test(Items.DYED_CANDLE.white().getDefaultInstance()) ||
+                    ing.test(Items.DYED_CANDLE.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (input.is(ItemTags.SHULKER_BOXES))
             {
-                if (ing.test(Items.WHITE_SHULKER_BOX.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_SHULKER_BOX.getDefaultInstance()))
+                if (ing.test(Items.DYED_SHULKER_BOX.white().getDefaultInstance()) ||
+                    ing.test(Items.DYED_SHULKER_BOX.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (input.is(ItemTags.BANNERS))
             {
-                if (ing.test(Items.WHITE_BANNER.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_BANNER.getDefaultInstance()))
+                if (ing.test(Items.BANNER.white().getDefaultInstance()) ||
+                    ing.test(Items.BANNER.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (input.is(ItemTags.TERRACOTTA))
             {
-                if (ing.test(Items.WHITE_TERRACOTTA.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_TERRACOTTA.getDefaultInstance()))
+                if (ing.test(Items.DYED_TERRACOTTA.white().getDefaultInstance()) ||
+                    ing.test(Items.DYED_TERRACOTTA.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (CachedTagUtils.matchItemTag(CachedTagManager.GLASS_ITEMS_KEY, input))
             {
-                if (ing.test(Items.WHITE_STAINED_GLASS.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_STAINED_GLASS.getDefaultInstance()))
+                if (ing.test(Items.STAINED_GLASS.white().getDefaultInstance()) ||
+                    ing.test(Items.STAINED_GLASS.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (CachedTagUtils.matchItemTag(CachedTagManager.GLASS_PANE_ITEMS_KEY, input))
             {
-                if (ing.test(Items.WHITE_STAINED_GLASS_PANE.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_STAINED_GLASS_PANE.getDefaultInstance()))
+                if (ing.test(Items.STAINED_GLASS_PANE.white().getDefaultInstance()) ||
+                    ing.test(Items.STAINED_GLASS_PANE.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (CachedTagUtils.matchItemTag(CachedTagManager.CONCRETE_ITEMS_KEY, input))
             {
-                if (ing.test(Items.WHITE_CONCRETE.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_CONCRETE.getDefaultInstance()))
+                if (ing.test(Items.CONCRETE.white().getDefaultInstance()) ||
+                    ing.test(Items.CONCRETE.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (CachedTagUtils.matchItemTag(CachedTagManager.CONCRETE_POWDER_ITEMS_KEY, input))
             {
-                if (ing.test(Items.WHITE_CONCRETE_POWDER.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_CONCRETE_POWDER.getDefaultInstance()))
+                if (ing.test(Items.CONCRETE_POWDER.white().getDefaultInstance()) ||
+                    ing.test(Items.CONCRETE_POWDER.black().getDefaultInstance()))
                 {
                     return true;
                 }
             }
             else if (CachedTagUtils.matchItemTag(CachedTagManager.GLAZED_TERRACOTTA_ITEMS_KEY, input))
             {
-                if (ing.test(Items.WHITE_GLAZED_TERRACOTTA.getDefaultInstance()) ||
-                    ing.test(Items.BLACK_GLAZED_TERRACOTTA.getDefaultInstance()))
+                if (ing.test(Items.GLAZED_TERRACOTTA.white().getDefaultInstance()) ||
+                    ing.test(Items.GLAZED_TERRACOTTA.black().getDefaultInstance()))
                 {
                     return true;
                 }

--- a/src/main/java/fi/dy/masa/litematica/mixin/model/IMixinEntityRenderDispatcher.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/model/IMixinEntityRenderDispatcher.java
@@ -1,0 +1,13 @@
+package fi.dy.masa.litematica.mixin.model;
+
+import net.minecraft.client.renderer.block.BlockModelResolver;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(EntityRenderDispatcher.class)
+public interface IMixinEntityRenderDispatcher
+{
+	@Accessor("blockModelResolver")
+	BlockModelResolver litematica_getBlockModelResolver();
+}

--- a/src/main/java/fi/dy/masa/litematica/mixin/model/IMixinMinecraft.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/model/IMixinMinecraft.java
@@ -1,7 +1,6 @@
 package fi.dy.masa.litematica.mixin.model;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.block.BlockModelResolver;
 import net.minecraft.client.renderer.item.ItemModelResolver;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -9,9 +8,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 @Mixin(Minecraft.class)
 public interface IMixinMinecraft
 {
-	@Accessor("blockModelResolver")
-	BlockModelResolver litematica_getBlockModelResolver();
-
 	@Accessor("itemModelResolver")
 	ItemModelResolver litematica_getItemModelResolver();
 }

--- a/src/main/java/fi/dy/masa/litematica/mixin/render/MixinLevelRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/render/MixinLevelRenderer.java
@@ -14,6 +14,8 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
+import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.SubmitNodeCollector;
@@ -21,6 +23,7 @@ import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
 import net.minecraft.client.renderer.culling.Frustum;
+import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.state.level.LevelRenderState;
 import net.minecraft.util.profiling.ActiveProfiler;
@@ -34,7 +37,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import fi.dy.masa.malilib.compat.iris.IrisCompat;
 import fi.dy.masa.litematica.compat.iris.IrisRenderingFix;
@@ -45,8 +47,6 @@ import fi.dy.masa.litematica.util.SchematicWorldRefresher;
 @Mixin(value = LevelRenderer.class, priority = 900)
 public abstract class MixinLevelRenderer
 {
-    @Shadow private ClientLevel level;
-    @Shadow @Final private Minecraft minecraft;
 	@Shadow @Final private SubmitNodeStorage submitNodeStorage;
 	@Shadow private @Nullable GpuSampler chunkLayerSampler;
 	@Shadow @Final private LevelRenderState levelRenderState;
@@ -65,11 +65,11 @@ public abstract class MixinLevelRenderer
         }
     }
 
-    @Inject(method = "allChanged()V", at = @At("RETURN"))
-    private void litematica_onLoadRenderers(CallbackInfo ci)
+    @Inject(method = "invalidateCompiledGeometry", at = @At("RETURN"))
+    private void litematica_onLoadRenderers(ClientLevel level, Options options, Camera camera, BlockColors blockColors, CallbackInfo ci)
     {
         // Also (re-)load our renderer when the vanilla renderer gets reloaded
-        if (this.level != null && this.level == this.minecraft.level)
+        if (level != null && level == Minecraft.getInstance().level)
         {
             this.litematica$prepareProfiler();
             LitematicaRenderer.getInstance().loadRenderers(this.profiler);
@@ -77,14 +77,20 @@ public abstract class MixinLevelRenderer
         }
     }
 
-    @Inject(method = "cullTerrain", at = @At("TAIL"))
-    private void litematica_onPostSetupTerrain(
-		    Camera camera, Frustum frustum, boolean spectator, CallbackInfo ci)
+    @Inject(method = "render", at = @At("HEAD"))
+    private void litematica_onRenderHead(GraphicsResourceAllocator resourceAllocator, DeltaTracker deltaTracker, boolean renderOutline,
+                                         CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog,
+                                         Vector4f fogColor, boolean shouldRenderSky, CallbackInfo ci)
     {
-        this.litematica$prepareProfiler();
-        LitematicaRenderer.getInstance().piecewisePrepare(frustum, this.profiler);
+        Camera camera = Minecraft.getInstance().gameRenderer.mainCamera();
+        Frustum frustum = cameraState.cullFrustum;
 
-	    // Why Iris?
+        this.litematica$prepareProfiler();
+        LitematicaRenderer renderer = LitematicaRenderer.getInstance();
+        renderer.piecewisePrepare(frustum, this.profiler);
+        renderer.piecewisePrepareEntities(camera, frustum, this.levelRenderState, deltaTracker, this.profiler);
+        renderer.piecewisePrepareBlockEntities(camera, this.levelRenderState, deltaTracker.getGameTimeDeltaPartialTick(true), this.profiler);
+
 	    if (IrisCompat.isShaderActive())
 	    {
 		    IrisRenderingFix.INSTANCE.setCamera(camera);
@@ -93,14 +99,13 @@ public abstract class MixinLevelRenderer
     }
 
     @Inject(method = "compileSections",
-            at = @At(value = "INVOKE",
-                     target = "Lnet/minecraft/util/profiling/ProfilerFiller;pop()V",
-                     ordinal = 1)
+            at = @At("TAIL")
     )
-    private void litematica_onPostUpdateChunks(Camera camera, CallbackInfo ci)
+    private void litematica_onPostUpdateChunks(CameraRenderState cameraState, CallbackInfo ci)
     {
 		if (IrisCompat.isShaderActive()) { return; }
         this.litematica$prepareProfiler();
+        Camera camera = Minecraft.getInstance().gameRenderer.mainCamera();
 	    LitematicaRenderer.getInstance().piecewiseUpdate(camera, this.profiler);
 
 		if (IrisCompat.hasSodium())
@@ -119,64 +124,51 @@ public abstract class MixinLevelRenderer
         }
     }
 
-    @Inject(method = "renderLevel",
+    @Inject(method = "render",
             at = @At(value = "INVOKE",
-                    target = "Lnet/minecraft/client/renderer/LevelRenderer;addMainPass(Lcom/mojang/blaze3d/framegraph/FrameGraphBuilder;Lnet/minecraft/client/renderer/culling/Frustum;Lorg/joml/Matrix4fc;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;ZLnet/minecraft/client/renderer/state/level/LevelRenderState;Lnet/minecraft/client/DeltaTracker;Lnet/minecraft/util/profiling/ProfilerFiller;Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;)V",
+                    target = "Lnet/minecraft/client/renderer/LevelRenderer;addMainPass(Lcom/mojang/blaze3d/framegraph/FrameGraphBuilder;Lnet/minecraft/client/renderer/feature/FeatureRenderDispatcher$PreparedFrame;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/level/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;)V",
                     shift = At.Shift.BEFORE))
     private void litematica_onPreRenderMain(GraphicsResourceAllocator resourceAllocator, DeltaTracker deltaTracker, boolean renderOutline,
-                                            CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog, Vector4f fogColor,
-                                            boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender, CallbackInfo ci,
-                                            @Local(name = "profiler") ProfilerFiller profiler)
+                                             CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog, Vector4f fogColor,
+                                             boolean shouldRenderSky, CallbackInfo ci,
+                                             @Local(ordinal = 0) ProfilerFiller profiler)
     {
         this.profiler = profiler;
 		if (IrisCompat.isShaderActive()) { return; }
-        LitematicaRenderer.getInstance().capturePreMainValues(cameraState, terrainFog, profiler);
-    }
-
-	@Inject(method = "extractLevel", at = @At("HEAD"))
-	private void litematica_onPrepareBlockLayersPre(DeltaTracker deltaTracker, Camera camera, float deltaPartialTick,
-													CallbackInfo ci)
-	{
-		// TODO -- NO extractLevel() are called while shader's are active
-//		LitematicaRenderer.getInstance().uploadRemainingBuffers(camera, deltaTracker, this.profiler);
-	}
-
-	@Inject(method = "prepareChunkRenders", at = @At("TAIL"))
-    private void litematica_onPrepareBlockLayersPost(Matrix4fc modelViewMatrix, CallbackInfoReturnable<ChunkSectionsToRender> cir)
-    {
-	    // Why Iris?
-	    if (!IrisCompat.isShaderActive())
-	    {
-		    this.litematica$prepareProfiler();
-		    LitematicaRenderer.getInstance().piecewisePrepareBlockLayers(modelViewMatrix, this.profiler);
-	    }
+        Camera camera = Minecraft.getInstance().gameRenderer.mainCamera();
+        LitematicaRenderer renderer = LitematicaRenderer.getInstance();
+        renderer.capturePreMainValues(cameraState, terrainFog, profiler);
+        renderer.uploadRemainingBuffers(camera, deltaTracker, profiler);
+        renderer.piecewisePrepareBlockLayers(modelViewMatrix, profiler);
     }
 
 	// BYTECODE (Virtual Method) Mixin for Section Group rendering
-	@Inject(method = "lambda$addMainPass$0(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/level/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;ZLorg/joml/Matrix4fc;)V",
+	@Inject(method = "lambda$addMainPass$0(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/level/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;Lcom/mojang/blaze3d/resource/ResourceHandle;Lnet/minecraft/client/renderer/feature/FeatureRenderDispatcher$PreparedFrame;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;)V",
 	        at = @At(value = "INVOKE",
 	                 target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V",
 	                 ordinal = 0,
 	                 shift = At.Shift.AFTER))
 	private void litematica_renderMainSection_Opaque(GpuBufferSlice terrainFog, LevelRenderState levelRenderState, ProfilerFiller profiler,
 	                                                 ChunkSectionsToRender chunkSectionsToRender, ResourceHandle<RenderTarget> entityOutlineTarget,
+	                                                 FeatureRenderDispatcher.PreparedFrame preparedFrame,
 	                                                 ResourceHandle<RenderTarget> translucentTarget, ResourceHandle<RenderTarget> mainTarget,
 	                                                 ResourceHandle<RenderTarget> itemEntityTarget, ResourceHandle<RenderTarget> particleTarget,
-	                                                 boolean renderOutline, Matrix4fc modelViewMatrix, CallbackInfo ci)
+	                                                 CallbackInfo ci)
 	{
 		LitematicaRenderer.getInstance().piecewiseDrawBlockLayerGroup(ChunkSectionLayerGroup.OPAQUE, this.chunkLayerSampler);
 	}
 
-	@Inject(method = "lambda$addMainPass$0(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/level/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;ZLorg/joml/Matrix4fc;)V",
+	@Inject(method = "lambda$addMainPass$0(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lnet/minecraft/client/renderer/state/level/LevelRenderState;Lnet/minecraft/util/profiling/ProfilerFiller;Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;Lcom/mojang/blaze3d/resource/ResourceHandle;Lnet/minecraft/client/renderer/feature/FeatureRenderDispatcher$PreparedFrame;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;Lcom/mojang/blaze3d/resource/ResourceHandle;)V",
 			at = @At(value = "INVOKE",
 					 target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V",
 					 ordinal = 1,
 					 shift = At.Shift.AFTER))
 	private void litematica_renderMainSection_Translucent(GpuBufferSlice terrainFog, LevelRenderState levelRenderState, ProfilerFiller profiler,
 	                                                      ChunkSectionsToRender chunkSectionsToRender, ResourceHandle<RenderTarget> entityOutlineTarget,
+	                                                      FeatureRenderDispatcher.PreparedFrame preparedFrame,
 	                                                      ResourceHandle<RenderTarget> translucentTarget, ResourceHandle<RenderTarget> mainTarget,
 	                                                      ResourceHandle<RenderTarget> itemEntityTarget, ResourceHandle<RenderTarget> particleTarget,
-	                                                      boolean renderOutline, Matrix4fc modelViewMatrix, CallbackInfo ci)
+	                                                      CallbackInfo ci)
 	{
 		LitematicaRenderer.getInstance().piecewiseDrawBlockLayerGroup(ChunkSectionLayerGroup.TRANSLUCENT, this.chunkLayerSampler);
 	}
@@ -193,21 +185,6 @@ public abstract class MixinLevelRenderer
 //		LitematicaRenderer.getInstance().piecewiseDrawBlockLayerGroup(ChunkSectionLayerGroup.TRIPWIRE, this.chunkLayerSampler);
 //	}
 
-	@Inject(method = "extractVisibleEntities", at = @At(value = "RETURN"))
-    private void litematica_onPostPrepareEntities(Camera camera, Frustum frustum, DeltaTracker deltaTracker, LevelRenderState output, CallbackInfo ci)
-    {
-	    // Why Iris?
-	    if (IrisCompat.isShaderActive()) { return; }
-	    this.litematica$prepareProfiler();
-        LitematicaRenderer.getInstance().piecewisePrepareEntities(camera, frustum, output, deltaTracker, this.profiler);
-
-		// Why Sodium?
-		if (IrisCompat.hasSodium())
-		{
-			LitematicaRenderer.getInstance().piecewisePrepareBlockEntities(camera, output, deltaTracker.getGameTimeDeltaPartialTick(true), this.profiler);
-		}
-    }
-
 	@Inject(method = "submitEntities", at = @At("RETURN"))
 	private void litematica_onPostRenderEntities(PoseStack poseStack, LevelRenderState levelRenderState, SubmitNodeCollector output, CallbackInfo ci)
 	{
@@ -215,19 +192,8 @@ public abstract class MixinLevelRenderer
 		LitematicaRenderer.getInstance().piecewiseRenderEntities(poseStack, levelRenderState, output, this.profiler);
 	}
 
-	@Inject(method = "extractVisibleBlockEntities", at = @At(value = "RETURN"))
-    private void litematica_onPostPrepareBlockEntities(Camera camera, float deltaPartialTick, LevelRenderState levelRenderState, CallbackInfo ci)
-    {
-		// Why Sodium?
-		if (!IrisCompat.hasSodium())
-		{
-			this.litematica$prepareProfiler();
-			LitematicaRenderer.getInstance().piecewisePrepareBlockEntities(camera, levelRenderState, deltaPartialTick, this.profiler);
-		}
-    }
-
     @Inject(method = "submitBlockEntities", at = @At(value = "RETURN"))
-    private void litematica_onPostRenderBlockEntities(PoseStack poseStack, LevelRenderState levelRenderState, SubmitNodeStorage submitNodeStorage, CallbackInfo ci)
+    private void litematica_onPostRenderBlockEntities(PoseStack poseStack, LevelRenderState levelRenderState, SubmitNodeCollector submitNodeCollector, CallbackInfo ci)
     {
         this.litematica$prepareProfiler();
         LitematicaRenderer.getInstance().piecewiseRenderBlockEntities(poseStack, levelRenderState, this.submitNodeStorage, this.profiler);

--- a/src/main/java/fi/dy/masa/litematica/render/IWorldSchematicRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/IWorldSchematicRenderer.java
@@ -147,7 +147,7 @@ public interface IWorldSchematicRenderer
 
 	static int getLightmap(LightGetter getter, BlockAndTintGetter world, BlockState state, BlockPos pos)
 	{
-		if (state.emissiveRendering(world, pos))
+		if (state.emissiveRendering())
 		{
 			return 15728880;
 		}

--- a/src/main/java/fi/dy/masa/litematica/render/IWorldSchematicRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/IWorldSchematicRenderer.java
@@ -2,6 +2,8 @@ package fi.dy.masa.litematica.render;
 
 import java.util.List;
 import javax.annotation.Nonnull;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
 import org.joml.Matrix4fc;
 import org.jspecify.annotations.Nullable;
 
@@ -118,7 +120,7 @@ public interface IWorldSchematicRenderer
 
 //	void updateBlockEntities(Collection<BlockEntity> toRemove, Collection<BlockEntity> toAdd);
 
-	void renderBlockOverlays(Camera camera, float lineWidth, ProfilerFiller profiler);
+	void renderBlockOverlays(RenderTarget fb, Camera camera, ProfilerFiller profiler);
 
 	void scheduleChunkRenders(int chunkX, int chunkZ, boolean immediate);
 

--- a/src/main/java/fi/dy/masa/litematica/render/LitematicaRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/LitematicaRenderer.java
@@ -1,6 +1,8 @@
 package fi.dy.masa.litematica.render;
 
 import javax.annotation.Nullable;
+
+import com.mojang.blaze3d.pipeline.RenderTarget;
 import org.joml.Matrix4fc;
 
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
@@ -142,21 +144,18 @@ public class LitematicaRenderer
         }
     }
 
-    public void renderSchematicOverlays(Camera camera, ProfilerFiller profiler)
+    public void renderSchematicOverlays(RenderTarget fb, Camera camera, ProfilerFiller profiler)
     {
         boolean invert = Hotkeys.INVERT_OVERLAY_RENDER_STATE.getKeybind().isKeybindHeld();
 
         if (Configs.Visuals.ENABLE_SCHEMATIC_OVERLAY.getBooleanValue() != invert)
         {
-            boolean renderThrough = Configs.Visuals.SCHEMATIC_OVERLAY_RENDER_THROUGH.getBooleanValue() || Hotkeys.RENDER_OVERLAY_THROUGH_BLOCKS.getKeybind().isKeybindHeld();
-            float lineWidth = (float) (renderThrough ? Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH_THROUGH.getDoubleValue() : Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH.getDoubleValue());
-
             profiler.push("schematic_overlay");
 
             if (!IrisCompat.isShadowPassActive())
             {
                 // this.getCamera()
-                this.getWorldRenderer().renderBlockOverlays(camera, lineWidth, profiler);
+                this.getWorldRenderer().renderBlockOverlays(fb, camera, profiler);
             }
 
             profiler.pop();
@@ -369,17 +368,17 @@ public class LitematicaRenderer
 		}
 	}
 
-	public void piecewiseRenderOverlay(ProfilerFiller profiler)
+	public void piecewiseRenderOverlay(RenderTarget fb, ProfilerFiller profiler)
     {
         if (this.renderPiecewiseSchematic)
         {
             profiler.push(Reference.MOD_ID+"_schematic_overlay");
-            this.renderSchematicOverlays(this.getCamera(), profiler);
+            this.renderSchematicOverlays(fb, this.getCamera(), profiler);
             profiler.pop();
         }
 
-		this.getWorldRenderer().clearWorldRenderStates();
-        this.cleanup();
+		//this.getWorldRenderer().clearWorldRenderStates();
+        //this.cleanup();
     }
 
     public void renderEntityDebugHitboxes(IEntityHitboxDebugRendererInvoker invoker, double cameraX, double cameraY, double cameraZ, DebugValueAccess debugValueAccess, Frustum frustum, float ticks, ProfilerFiller profiler)

--- a/src/main/java/fi/dy/masa/litematica/render/LitematicaRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/LitematicaRenderer.java
@@ -44,6 +44,8 @@ public class LitematicaRenderer
     private boolean renderPiecewiseEntities;
     private boolean renderPiecewiseTileEntities;
     private boolean renderEntityDebugHitboxes;
+    private int diagTerrainPathCalls;
+    private int diagTranslucentPathCalls;
 
     public static LitematicaRenderer getInstance()
     {
@@ -177,6 +179,8 @@ public class LitematicaRenderer
         this.renderPiecewiseBlocks = false;
         this.renderPiecewiseEntities = false;
         this.renderPiecewiseTileEntities = false;
+        this.diagTerrainPathCalls = 0;
+        this.diagTranslucentPathCalls = 0;
         this.camera = null;
         this.frustum = null;
         IWorldSchematicRenderer worldRenderer = this.getWorldRenderer();
@@ -297,9 +301,28 @@ public class LitematicaRenderer
     {
         if (this.renderPiecewiseBlocks)
         {
+            if (group == ChunkSectionLayerGroup.TRANSLUCENT)
+            {
+                ++this.diagTranslucentPathCalls;
+            }
+            else
+            {
+                ++this.diagTerrainPathCalls;
+            }
+
             // Use Saved Profiler later
             this.getWorldRenderer().drawBlockLayerGroup(group, sampler);
         }
+    }
+
+    public int getDiagTerrainPathCalls()
+    {
+        return this.diagTerrainPathCalls;
+    }
+
+    public int getDiagTranslucentPathCalls()
+    {
+        return this.diagTranslucentPathCalls;
     }
 
     public void piecewisePrepareEntities(Camera camera, Frustum frustum, LevelRenderState renderStates, DeltaTracker tickCounter, ProfilerFiller profiler)
@@ -373,7 +396,7 @@ public class LitematicaRenderer
     {
 	    if (this.camera == null)
         {
-            this.camera = this.mc.gameRenderer.getMainCamera();
+            this.camera = this.mc.gameRenderer.mainCamera();
         }
 
         return this.camera;

--- a/src/main/java/fi/dy/masa/litematica/render/OverlayRenderer.java
+++ b/src/main/java/fi/dy/masa/litematica/render/OverlayRenderer.java
@@ -59,6 +59,8 @@ import fi.dy.masa.litematica.world.SchematicWorldHandler;
 public class OverlayRenderer
 {
     private static final OverlayRenderer INSTANCE = new OverlayRenderer();
+    private static boolean diagAreaPathActive;
+    private static boolean diagPlacementPathActive;
 
     // https://stackoverflow.com/questions/470690/how-to-automatically-generate-n-distinct-colors
     public static final int[] KELLY_COLORS = {
@@ -113,6 +115,16 @@ public class OverlayRenderer
         return INSTANCE;
     }
 
+    public static boolean isDiagAreaPathActive()
+    {
+        return diagAreaPathActive;
+    }
+
+    public static boolean isDiagPlacementPathActive()
+    {
+        return diagPlacementPathActive;
+    }
+
     public void updatePlacementCache()
     {
         this.placements.clear();
@@ -138,6 +150,9 @@ public class OverlayRenderer
         float expand = 0.001f;
         float lineWidthBlockBox = 2f;
         float lineWidthArea = isProjectMode ? 3f : 1.5f;
+
+        diagAreaPathActive = renderAreas;
+        diagPlacementPathActive = renderPlacements || isProjectMode;
 
         if (renderAreas || renderPlacements || isProjectMode)
         {

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/BlockModelCacheSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/BlockModelCacheSchematic.java
@@ -187,7 +187,7 @@ public class BlockModelCacheSchematic
 	{
 		Litematica.LOGGER.info("BlockModelCacheSchematic: refreshing model cache");
 		this.modelManager = this.mc.getModelManager();
-		this.blockModelResolver = ((IMixinMinecraft) this.mc).litematica_getBlockModelResolver();
+		this.blockModelResolver = ((IMixinEntityRenderDispatcher) this.mc.getEntityRenderDispatcher()).litematica_getBlockModelResolver();
 		this.itemModelResolver = ((IMixinMinecraft) this.mc).litematica_getItemModelResolver();
 		this.blockStateModelSet = this.modelManager.getBlockStateModelSet();
 		this.blockModelSet = this.modelManager.getBlockModelSet();

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
@@ -49,6 +49,7 @@ import fi.dy.masa.malilib.util.data.Color4f;
 import fi.dy.masa.malilib.util.game.BlockUtils;
 import fi.dy.masa.litematica.Litematica;
 import fi.dy.masa.litematica.config.Configs;
+import fi.dy.masa.litematica.config.Hotkeys;
 import fi.dy.masa.litematica.data.DataManager;
 import fi.dy.masa.litematica.render.IWorldSchematicRenderer;
 import fi.dy.masa.litematica.render.RenderUtils;
@@ -70,6 +71,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
     private final RandomSource rand;
     protected final ReentrantLock chunkRenderLock;
     protected final ReentrantLock chunkRenderDataLock;
+    private final OverlayBuildStats overlayBuildStats;
     protected ProfilerFiller profiler;
     protected final BlockPos.MutableBlockPos position;
     protected final BlockPos.MutableBlockPos chunkRelativePos;
@@ -111,6 +113,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
         this.chunkRenderLock = new ReentrantLock();
 //		this.setBlockEntities = new HashSet<>();
         this.chunkRenderDataLock = new ReentrantLock();
+        this.overlayBuildStats = new OverlayBuildStats();
         this.position = new BlockPos.MutableBlockPos();
         this.chunkRelativePos = new BlockPos.MutableBlockPos();
 		this.boxes = new ArrayList<>();
@@ -125,6 +128,11 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
     public boolean hasOverlay()
     {
         return this.hasOverlay;
+    }
+
+    public OverlayBuildStats getOverlayBuildStats()
+    {
+        return this.overlayBuildStats;
     }
 
 	public boolean isEmpty()
@@ -698,6 +706,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
         this.existingOverlays.clear();
         this.hasOverlay = false;
+        this.overlayBuildStats.reset();
         this.getProfiler().popPush("rebuild_chunk_start");
         
         synchronized (this.boxes)
@@ -850,7 +859,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
             this.chunkRenderDataLock.unlock();
         }
 
-        if (this.worldRenderer.getChunkSchematicState(this.chunkPosition.x(), this.chunkPosition.z()).atLeast(ChunkSchematicState.RENDERED))
+        if (this.worldRenderer.getChunkSchematicState(this.chunkPosition.x(), this.chunkPosition.z()).atLeast(ChunkSchematicState.LOADED))
         {
             this.worldRenderer.setChunkSchematicState(this.chunkPosition.x(), this.chunkPosition.z(), ChunkSchematicState.RENDERED);
         }
@@ -929,6 +938,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
             OverlayType type = this.getOverlayType(stateSchematic, stateClient);
 
             this.overlayColor = getOverlayColor(type);
+            this.overlayBuildStats.recordType(type, this.overlayColor);
 
             if (this.overlayColor != null)
             {
@@ -1109,7 +1119,11 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
             }
 
             Color4f overlayColor = new Color4f(this.overlayColor.r, this.overlayColor.g, this.overlayColor.b, 1f);
-	        float lineWidth = 1.0f;
+            boolean renderThrough = Configs.Visuals.SCHEMATIC_OVERLAY_RENDER_THROUGH.getBooleanValue() ||
+                                    Hotkeys.RENDER_OVERLAY_THROUGH_BLOCKS.getKeybind().isKeybindHeld();
+            float lineWidth = (float) (renderThrough ?
+                                       Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH_THROUGH.getDoubleValue() :
+                                       Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH.getDoubleValue());
 
             this.getProfiler().popPush("cull_inner_sides");
             if (Configs.Visuals.OVERLAY_REDUCED_INNER_SIDES.getBooleanValue())
@@ -1180,7 +1194,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                 else
                 {
                     this.getProfiler().popPush("render_reduced_edges");
-                    this.renderOverlayReducedEdges(pos, adjTypes, type, lineWidth, bufferOverlayOutlines);
+                    this.renderOverlayReducedEdges(pos, adjTypes, type, overlayColor, lineWidth, bufferOverlayOutlines);
                     //RenderUtils.drawBlockBoundingBoxOutlinesBatchedLines(pos, relPos, overlayColor, 0, bufferOverlayOutlines);
                 }
             }
@@ -1226,7 +1240,8 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
         return this.chunkRelativePos.set(pos.getX() & 0xF, pos.getY() - this.position.getY(), pos.getZ() & 0xF);
     }
 
-    protected void renderOverlayReducedEdges(BlockPos pos, OverlayType[][][] adjTypes, OverlayType typeSelf, float lineWidth, BufferBuilder bufferOverlayOutlines)
+    protected void renderOverlayReducedEdges(BlockPos pos, OverlayType[][][] adjTypes, OverlayType typeSelf, Color4f overlayColor,
+                                             float lineWidth, BufferBuilder bufferOverlayOutlines)
     {
         OverlayType[] neighborTypes = new OverlayType[4];
         Vec3i[] neighborPositions = new Vec3i[4];
@@ -1304,7 +1319,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                         try
                         {
                             this.getProfiler().popPush("render_batched");
-                            RenderUtils.drawBlockBoxEdgeBatchedDebugLines(this.getChunkRelativePosition(pos), axis, corner, this.overlayColor, lineWidth, bufferOverlayOutlines);
+                            RenderUtils.drawBlockBoxEdgeBatchedDebugLines(this.getChunkRelativePosition(pos), axis, corner, overlayColor, lineWidth, bufferOverlayOutlines);
                         }
                         catch (IllegalStateException ignored)
                         {
@@ -1428,7 +1443,25 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
             default:
         }
 
+        if (overlayColor != null && Boolean.getBoolean("litematica.debug.schematicOverlay.forceColors"))
+        {
+            return getForcedDebugOverlayColor(overlayType);
+        }
+
         return overlayColor;
+    }
+
+    private static Color4f getForcedDebugOverlayColor(OverlayType overlayType)
+    {
+        return switch (overlayType)
+        {
+            case MISSING     -> Color4f.fromColor(0xFFFF0000);
+            case EXTRA       -> Color4f.fromColor(0xFFFF00FF);
+            case WRONG_BLOCK -> Color4f.fromColor(0xFF8000FF);
+            case WRONG_STATE -> Color4f.fromColor(0xFFFFFF00);
+            case DIFF_BLOCK  -> Color4f.fromColor(0xFF00FFFF);
+            default          -> Color4f.fromColor(0xFFFFFFFF);
+        };
     }
 
     private <T extends BlockEntity> void addBlockEntity(BlockPos pos, ChunkMeshDataSchematic chunkMeshData)
@@ -1838,6 +1871,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                 else
                 {
 //                    LOGGER.warn("[VBO] postRenderBlocks(): type: [{}] -- Save Mesh Data; VC: [{}]", type.name(), meshData.drawState().vertexCount());
+                    this.overlayBuildStats.recordVertices(type, meshData.drawState().vertexCount());
                     chunkMeshData.saveMeshData(type, meshData);
                 }
             }
@@ -1861,6 +1895,104 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
         }
 
 //        LOGGER.warn("[VBO] postRenderBlocks(): type: [{}] --> END", type.name());
+    }
+
+    public static class OverlayBuildStats
+    {
+        private final EnumMap<OverlayType, Integer> typeCounts = new EnumMap<>(OverlayType.class);
+        private final Map<String, Integer> colorCounts = new LinkedHashMap<>();
+        private int quadVertices;
+        private int outlineVertices;
+
+        public synchronized void reset()
+        {
+            this.typeCounts.clear();
+            this.colorCounts.clear();
+            this.quadVertices = 0;
+            this.outlineVertices = 0;
+        }
+
+        public synchronized void recordType(OverlayType type, @Nullable Color4f color)
+        {
+            this.typeCounts.merge(type, 1, Integer::sum);
+
+            if (color != null)
+            {
+                this.colorCounts.merge(color.toHexString(), 1, Integer::sum);
+            }
+        }
+
+        public synchronized void recordVertices(OverlayRenderType type, int vertices)
+        {
+            if (type == OverlayRenderType.QUAD)
+            {
+                this.quadVertices += vertices;
+            }
+            else if (type == OverlayRenderType.OUTLINE)
+            {
+                this.outlineVertices += vertices;
+            }
+        }
+
+        public synchronized void mergeInto(OverlayBuildStats target)
+        {
+            for (Map.Entry<OverlayType, Integer> entry : this.typeCounts.entrySet())
+            {
+                target.typeCounts.merge(entry.getKey(), entry.getValue(), Integer::sum);
+            }
+
+            for (Map.Entry<String, Integer> entry : this.colorCounts.entrySet())
+            {
+                target.colorCounts.merge(entry.getKey(), entry.getValue(), Integer::sum);
+            }
+
+            target.quadVertices += this.quadVertices;
+            target.outlineVertices += this.outlineVertices;
+        }
+
+        public synchronized int getTotalChecked()
+        {
+            int total = 0;
+
+            for (int count : this.typeCounts.values())
+            {
+                total += count;
+            }
+
+            return total;
+        }
+
+        public synchronized String getTypeCountsString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            for (OverlayType type : OverlayType.values())
+            {
+                if (!sb.isEmpty())
+                {
+                    sb.append(", ");
+                }
+
+                sb.append(type.name()).append('=').append(this.typeCounts.getOrDefault(type, 0));
+            }
+
+            return sb.toString();
+        }
+
+        public synchronized String getColorCountsString()
+        {
+            return this.colorCounts.toString();
+        }
+
+        public synchronized int getQuadVertices()
+        {
+            return this.quadVertices;
+        }
+
+        public synchronized int getOutlineVertices()
+        {
+            return this.outlineVertices;
+        }
     }
 
     protected VertexSorting createVertexSorter(float x, float y, float z)

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
@@ -71,7 +71,6 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
     private final RandomSource rand;
     protected final ReentrantLock chunkRenderLock;
     protected final ReentrantLock chunkRenderDataLock;
-    private final OverlayBuildStats overlayBuildStats;
     protected ProfilerFiller profiler;
     protected final BlockPos.MutableBlockPos position;
     protected final BlockPos.MutableBlockPos chunkRelativePos;
@@ -113,7 +112,6 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
         this.chunkRenderLock = new ReentrantLock();
 //		this.setBlockEntities = new HashSet<>();
         this.chunkRenderDataLock = new ReentrantLock();
-        this.overlayBuildStats = new OverlayBuildStats();
         this.position = new BlockPos.MutableBlockPos();
         this.chunkRelativePos = new BlockPos.MutableBlockPos();
 		this.boxes = new ArrayList<>();
@@ -128,11 +126,6 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
     public boolean hasOverlay()
     {
         return this.hasOverlay;
-    }
-
-    public OverlayBuildStats getOverlayBuildStats()
-    {
-        return this.overlayBuildStats;
     }
 
 	public boolean isEmpty()
@@ -706,7 +699,6 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
         this.existingOverlays.clear();
         this.hasOverlay = false;
-        this.overlayBuildStats.reset();
         this.getProfiler().popPush("rebuild_chunk_start");
         
         synchronized (this.boxes)
@@ -938,7 +930,6 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
             OverlayType type = this.getOverlayType(stateSchematic, stateClient);
 
             this.overlayColor = getOverlayColor(type);
-            this.overlayBuildStats.recordType(type, this.overlayColor);
 
             if (this.overlayColor != null)
             {
@@ -1443,25 +1434,7 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
             default:
         }
 
-        if (overlayColor != null && Boolean.getBoolean("litematica.debug.schematicOverlay.forceColors"))
-        {
-            return getForcedDebugOverlayColor(overlayType);
-        }
-
         return overlayColor;
-    }
-
-    private static Color4f getForcedDebugOverlayColor(OverlayType overlayType)
-    {
-        return switch (overlayType)
-        {
-            case MISSING     -> Color4f.fromColor(0xFFFF0000);
-            case EXTRA       -> Color4f.fromColor(0xFFFF00FF);
-            case WRONG_BLOCK -> Color4f.fromColor(0xFF8000FF);
-            case WRONG_STATE -> Color4f.fromColor(0xFFFFFF00);
-            case DIFF_BLOCK  -> Color4f.fromColor(0xFF00FFFF);
-            default          -> Color4f.fromColor(0xFFFFFFFF);
-        };
     }
 
     private <T extends BlockEntity> void addBlockEntity(BlockPos pos, ChunkMeshDataSchematic chunkMeshData)
@@ -1511,17 +1484,6 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
 
         if (gpuBuffers != null)
         {
-            if (gpuBuffers.vertexBuffer != null)
-            {
-                gpuBuffers.vertexBuffer.close();
-            }
-
-            if (gpuBuffers.indexBuffer != null)
-            {
-                gpuBuffers.indexBuffer.close();
-                gpuBuffers.indexBuffer = null;
-            }
-
             CommandEncoder encoder = RenderSystem.getDevice().createCommandEncoder();
 
             if (gpuBuffers.vertexBuffer.size() < meshData.vertexBuffer().remaining())
@@ -1871,7 +1833,6 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
                 else
                 {
 //                    LOGGER.warn("[VBO] postRenderBlocks(): type: [{}] -- Save Mesh Data; VC: [{}]", type.name(), meshData.drawState().vertexCount());
-                    this.overlayBuildStats.recordVertices(type, meshData.drawState().vertexCount());
                     chunkMeshData.saveMeshData(type, meshData);
                 }
             }
@@ -1895,104 +1856,6 @@ public class ChunkRendererSchematicVbo implements AutoCloseable
         }
 
 //        LOGGER.warn("[VBO] postRenderBlocks(): type: [{}] --> END", type.name());
-    }
-
-    public static class OverlayBuildStats
-    {
-        private final EnumMap<OverlayType, Integer> typeCounts = new EnumMap<>(OverlayType.class);
-        private final Map<String, Integer> colorCounts = new LinkedHashMap<>();
-        private int quadVertices;
-        private int outlineVertices;
-
-        public synchronized void reset()
-        {
-            this.typeCounts.clear();
-            this.colorCounts.clear();
-            this.quadVertices = 0;
-            this.outlineVertices = 0;
-        }
-
-        public synchronized void recordType(OverlayType type, @Nullable Color4f color)
-        {
-            this.typeCounts.merge(type, 1, Integer::sum);
-
-            if (color != null)
-            {
-                this.colorCounts.merge(color.toHexString(), 1, Integer::sum);
-            }
-        }
-
-        public synchronized void recordVertices(OverlayRenderType type, int vertices)
-        {
-            if (type == OverlayRenderType.QUAD)
-            {
-                this.quadVertices += vertices;
-            }
-            else if (type == OverlayRenderType.OUTLINE)
-            {
-                this.outlineVertices += vertices;
-            }
-        }
-
-        public synchronized void mergeInto(OverlayBuildStats target)
-        {
-            for (Map.Entry<OverlayType, Integer> entry : this.typeCounts.entrySet())
-            {
-                target.typeCounts.merge(entry.getKey(), entry.getValue(), Integer::sum);
-            }
-
-            for (Map.Entry<String, Integer> entry : this.colorCounts.entrySet())
-            {
-                target.colorCounts.merge(entry.getKey(), entry.getValue(), Integer::sum);
-            }
-
-            target.quadVertices += this.quadVertices;
-            target.outlineVertices += this.outlineVertices;
-        }
-
-        public synchronized int getTotalChecked()
-        {
-            int total = 0;
-
-            for (int count : this.typeCounts.values())
-            {
-                total += count;
-            }
-
-            return total;
-        }
-
-        public synchronized String getTypeCountsString()
-        {
-            StringBuilder sb = new StringBuilder();
-
-            for (OverlayType type : OverlayType.values())
-            {
-                if (!sb.isEmpty())
-                {
-                    sb.append(", ");
-                }
-
-                sb.append(type.name()).append('=').append(this.typeCounts.getOrDefault(type, 0));
-            }
-
-            return sb.toString();
-        }
-
-        public synchronized String getColorCountsString()
-        {
-            return this.colorCounts.toString();
-        }
-
-        public synchronized int getQuadVertices()
-        {
-            return this.quadVertices;
-        }
-
-        public synchronized int getOutlineVertices()
-        {
-            return this.outlineVertices;
-        }
     }
 
     protected VertexSorting createVertexSorter(float x, float y, float z)

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/FallbackBlocks.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/FallbackBlocks.java
@@ -1,6 +1,7 @@
 package fi.dy.masa.litematica.render.schematic;
 
 import java.util.HashMap;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -20,43 +21,50 @@ public class FallbackBlocks
 	public static HashMap<Identifier, StateDefinition<Block, BlockState>> ID_TO_STATE_MANAGER = new HashMap<>();
 
 	// Glass Blocks
-	public static Identifier BLACK_GLASS = registerBasic("black_glass_fallback", Blocks.BLACK_STAINED_GLASS);
-	public static Identifier BLUE_GLASS = registerBasic("blue_glass_fallback", Blocks.BLUE_STAINED_GLASS);
-	public static Identifier BROWN_GLASS = registerBasic("brown_glass_fallback", Blocks.BROWN_STAINED_GLASS);
-	public static Identifier CYAN_GLASS = registerBasic("cyan_glass_fallback", Blocks.CYAN_STAINED_GLASS);
+	public static Identifier BLACK_GLASS = registerBasic("black_glass_fallback", block("black_stained_glass"));
+	public static Identifier BLUE_GLASS = registerBasic("blue_glass_fallback", block("blue_stained_glass"));
+	public static Identifier BROWN_GLASS = registerBasic("brown_glass_fallback", block("brown_stained_glass"));
+	public static Identifier CYAN_GLASS = registerBasic("cyan_glass_fallback", block("cyan_stained_glass"));
 	public static Identifier GLASS = registerBasic("glass_fallback", Blocks.GLASS);
-	public static Identifier GRAY_GLASS = registerBasic("gray_glass_fallback", Blocks.GRAY_STAINED_GLASS);
-	public static Identifier GREEN_GLASS = registerBasic("green_glass_fallback", Blocks.GREEN_STAINED_GLASS);
-	public static Identifier LIME_GLASS = registerBasic("lime_glass_fallback", Blocks.LIME_STAINED_GLASS);
-	public static Identifier LT_BLUE_GLASS = registerBasic("lt_blue_glass_fallback", Blocks.LIGHT_BLUE_STAINED_GLASS);
-	public static Identifier LT_GRAY_GLASS = registerBasic("lt_gray_glass_fallback", Blocks.LIGHT_GRAY_STAINED_GLASS);
-	public static Identifier MAGENTA_GLASS = registerBasic("magenta_glass_fallback", Blocks.MAGENTA_STAINED_GLASS);
-	public static Identifier ORANGE_GLASS = registerBasic("orange_glass_fallback", Blocks.ORANGE_STAINED_GLASS);
-	public static Identifier PINK_GLASS = registerBasic("pink_glass_fallback", Blocks.PINK_STAINED_GLASS);
-	public static Identifier PURPLE_GLASS = registerBasic("purple_glass_fallback", Blocks.PURPLE_STAINED_GLASS);
-	public static Identifier RED_GLASS = registerBasic("red_glass_fallback", Blocks.RED_STAINED_GLASS);
+	public static Identifier GRAY_GLASS = registerBasic("gray_glass_fallback", block("gray_stained_glass"));
+	public static Identifier GREEN_GLASS = registerBasic("green_glass_fallback", block("green_stained_glass"));
+	public static Identifier LIME_GLASS = registerBasic("lime_glass_fallback", block("lime_stained_glass"));
+	public static Identifier LT_BLUE_GLASS = registerBasic("lt_blue_glass_fallback", block("light_blue_stained_glass"));
+	public static Identifier LT_GRAY_GLASS = registerBasic("lt_gray_glass_fallback", block("light_gray_stained_glass"));
+	public static Identifier MAGENTA_GLASS = registerBasic("magenta_glass_fallback", block("magenta_stained_glass"));
+	public static Identifier ORANGE_GLASS = registerBasic("orange_glass_fallback", block("orange_stained_glass"));
+	public static Identifier PINK_GLASS = registerBasic("pink_glass_fallback", block("pink_stained_glass"));
+	public static Identifier PURPLE_GLASS = registerBasic("purple_glass_fallback", block("purple_stained_glass"));
+	public static Identifier RED_GLASS = registerBasic("red_glass_fallback", block("red_stained_glass"));
 	public static Identifier TINTED_GLASS = registerBasic("tinted_glass_fallback", Blocks.TINTED_GLASS);
-	public static Identifier WHITE_GLASS = registerBasic("white_glass_fallback", Blocks.WHITE_STAINED_GLASS);
-	public static Identifier YELLOW_GLASS = registerBasic("yellow_glass_fallback", Blocks.YELLOW_STAINED_GLASS);
+	public static Identifier WHITE_GLASS = registerBasic("white_glass_fallback", block("white_stained_glass"));
+	public static Identifier YELLOW_GLASS = registerBasic("yellow_glass_fallback", block("yellow_stained_glass"));
 
 	// Glass Panes
-	public static Identifier BLACK_GLASS_PANE = registerHorizontalConnecting("black_glass_pane_fallback", Blocks.BLACK_STAINED_GLASS_PANE);
-	public static Identifier BLUE_GLASS_PANE = registerHorizontalConnecting("blue_glass_pane_fallback", Blocks.BLUE_STAINED_GLASS_PANE);
-	public static Identifier BROWN_GLASS_PANE = registerHorizontalConnecting("brown_glass_pane_fallback", Blocks.BROWN_STAINED_GLASS_PANE);
-	public static Identifier CYAN_GLASS_PANE = registerHorizontalConnecting("cyan_glass_pane_fallback", Blocks.CYAN_STAINED_GLASS_PANE);
+	public static Identifier BLACK_GLASS_PANE = registerHorizontalConnecting("black_glass_pane_fallback", block("black_stained_glass_pane"));
+	public static Identifier BLUE_GLASS_PANE = registerHorizontalConnecting("blue_glass_pane_fallback", block("blue_stained_glass_pane"));
+	public static Identifier BROWN_GLASS_PANE = registerHorizontalConnecting("brown_glass_pane_fallback", block("brown_stained_glass_pane"));
+	public static Identifier CYAN_GLASS_PANE = registerHorizontalConnecting("cyan_glass_pane_fallback", block("cyan_stained_glass_pane"));
 	public static Identifier GLASS_PANE = registerHorizontalConnecting("glass_pane_fallback", Blocks.GLASS_PANE);
-	public static Identifier GRAY_GLASS_PANE = registerHorizontalConnecting("gray_glass_pane_fallback", Blocks.GRAY_STAINED_GLASS_PANE);
-	public static Identifier GREEN_GLASS_PANE = registerHorizontalConnecting("green_glass_pane_fallback", Blocks.GREEN_STAINED_GLASS_PANE);
-	public static Identifier LIME_GLASS_PANE = registerHorizontalConnecting("lime_glass_pane_fallback", Blocks.LIME_STAINED_GLASS_PANE);
-	public static Identifier LT_BLUE_GLASS_PANE = registerHorizontalConnecting("lt_blue_glass_pane_fallback", Blocks.LIGHT_BLUE_STAINED_GLASS_PANE);
-	public static Identifier LT_GRAY_GLASS_PANE = registerHorizontalConnecting("lt_gray_glass_pane_fallback", Blocks.LIGHT_GRAY_STAINED_GLASS_PANE);
-	public static Identifier MAGENTA_GLASS_PANE = registerHorizontalConnecting("magenta_glass_pane_fallback", Blocks.MAGENTA_STAINED_GLASS_PANE);
-	public static Identifier ORANGE_GLASS_PANE = registerHorizontalConnecting("orange_glass_pane_fallback", Blocks.ORANGE_STAINED_GLASS_PANE);
-	public static Identifier PINK_GLASS_PANE = registerHorizontalConnecting("pink_glass_pane_fallback", Blocks.PINK_STAINED_GLASS_PANE);
-	public static Identifier PURPLE_GLASS_PANE = registerHorizontalConnecting("purple_glass_pane_fallback", Blocks.PURPLE_STAINED_GLASS_PANE);
-	public static Identifier RED_GLASS_PANE = registerHorizontalConnecting("red_glass_pane_fallback", Blocks.RED_STAINED_GLASS_PANE);
-	public static Identifier WHITE_GLASS_PANE = registerHorizontalConnecting("white_glass_pane_fallback", Blocks.WHITE_STAINED_GLASS_PANE);
-	public static Identifier YELLOW_GLASS_PANE = registerHorizontalConnecting("yellow_glass_pane_fallback", Blocks.YELLOW_STAINED_GLASS_PANE);
+	public static Identifier GRAY_GLASS_PANE = registerHorizontalConnecting("gray_glass_pane_fallback", block("gray_stained_glass_pane"));
+	public static Identifier GREEN_GLASS_PANE = registerHorizontalConnecting("green_glass_pane_fallback", block("green_stained_glass_pane"));
+	public static Identifier LIME_GLASS_PANE = registerHorizontalConnecting("lime_glass_pane_fallback", block("lime_stained_glass_pane"));
+	public static Identifier LT_BLUE_GLASS_PANE = registerHorizontalConnecting("lt_blue_glass_pane_fallback", block("light_blue_stained_glass_pane"));
+	public static Identifier LT_GRAY_GLASS_PANE = registerHorizontalConnecting("lt_gray_glass_pane_fallback", block("light_gray_stained_glass_pane"));
+	public static Identifier MAGENTA_GLASS_PANE = registerHorizontalConnecting("magenta_glass_pane_fallback", block("magenta_stained_glass_pane"));
+	public static Identifier ORANGE_GLASS_PANE = registerHorizontalConnecting("orange_glass_pane_fallback", block("orange_stained_glass_pane"));
+	public static Identifier PINK_GLASS_PANE = registerHorizontalConnecting("pink_glass_pane_fallback", block("pink_stained_glass_pane"));
+	public static Identifier PURPLE_GLASS_PANE = registerHorizontalConnecting("purple_glass_pane_fallback", block("purple_stained_glass_pane"));
+	public static Identifier RED_GLASS_PANE = registerHorizontalConnecting("red_glass_pane_fallback", block("red_stained_glass_pane"));
+	public static Identifier WHITE_GLASS_PANE = registerHorizontalConnecting("white_glass_pane_fallback", block("white_stained_glass_pane"));
+	public static Identifier YELLOW_GLASS_PANE = registerHorizontalConnecting("yellow_glass_pane_fallback", block("yellow_stained_glass_pane"));
+
+	private static Block block(String path)
+	{
+		Identifier id = Identifier.withDefaultNamespace(path);
+		Block block = BuiltInRegistries.BLOCK.getValue(id);
+		return block == null ? Blocks.AIR : block;
+	}
 
 	private static Identifier registerBasic(String name, Block block)
 	{

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/UberBufferCache.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/UberBufferCache.java
@@ -4,9 +4,9 @@ import java.util.Collection;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-import com.mojang.blaze3d.GraphicsWorkarounds;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.StagingBuffer;
 import com.mojang.blaze3d.vertex.UberGpuBuffer;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
@@ -31,17 +31,16 @@ public class UberBufferCache implements AutoCloseable
 		int vboStageSize = 33554432;
 		int iboStageSize = 2097152;
 		GpuDevice gpuDevice = RenderSystem.getDevice();
-		GraphicsWorkarounds workarounds = GraphicsWorkarounds.get(gpuDevice);
 		this.blockBuffers = Util.makeEnumMap(
 				ChunkSectionLayer.class,
 				layer ->
 				{
 					VertexFormat vertexFormat = layer.pipeline().getVertexFormat();
 					UberGpuBuffer<ChunkMeshDataSchematic> vertexUberBuffer = new UberGpuBuffer<>(
-							layer.label(), 32, vboHeapSize, vertexFormat.getVertexSize(), gpuDevice, vboStageSize, workarounds
+							layer.label(), 32, vboHeapSize, vertexFormat.getVertexSize(), StagingBuffer.create(layer.label(), gpuDevice, vboStageSize)
 					);
 					UberGpuBuffer<ChunkMeshDataSchematic> indexUberBuffer = layer == ChunkSectionLayer.TRANSLUCENT
-					                                                        ? new UberGpuBuffer<>(layer.label(), 64, iboHeapSize, 8, gpuDevice, iboStageSize, workarounds)
+					                                                        ? new UberGpuBuffer<>(layer.label(), 64, iboHeapSize, 8, StagingBuffer.create(layer.label(), gpuDevice, iboStageSize))
 					                                                        : null;
 					return new ChunkRenderUberBuffers(vertexUberBuffer, indexUberBuffer);
 				}
@@ -52,10 +51,10 @@ public class UberBufferCache implements AutoCloseable
 				{
 					VertexFormat vertexFormat = type.getPipeline().getVertexFormat();
 					UberGpuBuffer<ChunkMeshDataSchematic> vertexUberBuffer = new UberGpuBuffer<>(
-							type.name(), 32, vboHeapSize, vertexFormat.getVertexSize(), gpuDevice, vboStageSize, workarounds
+							type.name(), 32, vboHeapSize, vertexFormat.getVertexSize(), StagingBuffer.create(type.name(), gpuDevice, vboStageSize)
 					);
 					UberGpuBuffer<ChunkMeshDataSchematic> indexUberBuffer = type.isTranslucent()
-					                                                        ? new UberGpuBuffer<>(type.name(), 64, iboHeapSize, 8, gpuDevice, iboStageSize, workarounds)
+					                                                        ? new UberGpuBuffer<>(type.name(), 64, iboHeapSize, 8, StagingBuffer.create(type.name(), gpuDevice, iboStageSize))
 					                                                        : null;
 					return new ChunkRenderUberBuffers(vertexUberBuffer, indexUberBuffer);
 				}

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
@@ -17,8 +17,10 @@ import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.systems.ScissorState;
 import com.mojang.blaze3d.textures.AddressMode;
 import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuSampler;
@@ -101,6 +103,7 @@ import fi.dy.masa.litematica.world.WorldSchematic;
 public class WorldRendererSchematic implements IWorldSchematicRenderer
 {
     private static final String STATUS_OVERLAY_TIMING_PROPERTY = "litematica.debug.schematicOverlayTiming";
+    private static final String STATUS_OVERLAY_FORCE_FALLBACK_PROPERTY = "litematica.debug.schematicOverlay.forceFallback";
     private static final long STATUS_OVERLAY_TIMING_LOG_INTERVAL_MS = 5000L;
     private static final Logger LOGGER = Litematica.LOGGER;
     private final Minecraft mc;
@@ -123,6 +126,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     private float lastCameraYaw;
     private ChunkRenderDispatcherLitematica renderDispatcher;
     private final IChunkRendererFactory renderChunkFactory;
+    private final IdentityHashMap<ChunkRendererSchematicVbo, EnumMap<OverlayRenderType, CachedStatusOverlayMesh>> statusOverlayCache;
     //private ShaderGroup entityOutlineShader;
     //private boolean entityOutlinesRendered;
 
@@ -133,10 +137,17 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     private int countEntitiesRendered;
     private int countEntitiesHidden;
     private long statusOverlayTimingLastLogTime;
-    private long statusOverlayTimingNanos;
+    private long statusOverlayTimingFallbackNanos;
+    private long statusOverlayTimingFallbackDraws;
+    private long statusOverlayTimingCachedNanos;
+    private long statusOverlayTimingCachedBuffers;
+    private long statusOverlayTimingCachedDraws;
+    private long statusOverlayTimingCacheBuildNanos;
+    private long statusOverlayTimingCacheBuilds;
+    private long statusOverlayTimingCacheBuildVertices;
     private long statusOverlayTimingChunks;
-    private long statusOverlayTimingVertices;
-    private long statusOverlayTimingDraws;
+    private long statusOverlayTimingVerticesCopied;
+    private boolean statusOverlayCacheWarningLogged;
 
     private double lastTranslucentSortX;
     private double lastTranslucentSortY;
@@ -144,12 +155,17 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     private boolean needsUpdate;
     private boolean shouldDraw;
 
+    private static final String RENDER_MODE_INVALIDATION_PROPERTY = "litematica.debug.renderModeInvalidation";
+
+    private int lastLayerRenderSignature = Integer.MIN_VALUE;
+
     public WorldRendererSchematic(Minecraft mc)
     {
         this.mc = mc;
         this.renderChunkFactory = ChunkRendererSchematicVbo::new;
 //	    this.blockEntities = new HashSet<>();
 	    this.renderInfos = new ArrayList<>(1024);
+        this.statusOverlayCache = new IdentityHashMap<>();
         this.renderedEntities = new HashMap<>();
 		this.schematicRenderState = this.getSchematicRenderState();
 	    this.chunksToUpdate = new LinkedHashSet<>();
@@ -334,6 +350,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         }
         else
         {
+            this.closeStatusOverlayCache();
             this.chunksToUpdate.forEach(ChunkRendererSchematicVbo::deleteGlResources);
             this.chunksToUpdate.clear();
             this.renderInfos.forEach(ChunkRendererSchematicVbo::deleteGlResources);
@@ -384,6 +401,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
             this.profiler = profiler;
 
             profiler.push("load_renderers");
+            this.closeStatusOverlayCache();
 
             if (this.renderDispatcher == null)
             {
@@ -418,6 +436,8 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     protected void stopChunkUpdates(ProfilerFiller profiler)
     {
 //        LOGGER.warn("[WorldRenderer] stopChunkUpdates()");
+        this.closeStatusOverlayCache();
+
         if (!this.chunksToUpdate.isEmpty())
         {
             this.chunksToUpdate.forEach(ChunkRendererSchematicVbo::deleteGlResources);
@@ -476,6 +496,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         double cameraZ = cameraPos.z;
 
         this.renderDispatcher.setCameraPosition(cameraPos);
+        this.checkLayerRenderStateChanged();
 
         profiler.popPush("culling");
         BlockPos viewPos = BlockPos.containing(cameraX, cameraY + (double) entity.getEyeHeight(), cameraZ);
@@ -1083,14 +1104,16 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     {
         this.profiler = profiler;
         boolean timingEnabled = isStatusOverlayTimingEnabled();
+        boolean forceFallback = isStatusOverlayForceFallbackEnabled();
 
         // Draw filled status faces first so the final colored outlines remain visible.
-        this.renderBlockOverlay(fb, OverlayRenderType.QUAD, camera, profiler, timingEnabled);
-        this.renderBlockOverlay(fb, OverlayRenderType.OUTLINE, camera, profiler, timingEnabled);
+        this.renderBlockOverlay(fb, OverlayRenderType.QUAD, camera, profiler, timingEnabled, forceFallback);
+        this.renderBlockOverlay(fb, OverlayRenderType.OUTLINE, camera, profiler, timingEnabled, forceFallback);
         this.logStatusOverlayTimingIfNeeded(timingEnabled);
     }
 
-    protected void renderBlockOverlay(RenderTarget fb, OverlayRenderType type, Camera camera, ProfilerFiller profiler, boolean timingEnabled)
+    protected void renderBlockOverlay(RenderTarget fb, OverlayRenderType type, Camera camera, ProfilerFiller profiler,
+                                      boolean timingEnabled, boolean forceFallback)
     {
         profiler.push("overlay_" + type.name());
         this.profiler = profiler;
@@ -1120,6 +1143,11 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                 {
                     BlockPos chunkOrigin = renderer.getOrigin();
 
+                    if (timingEnabled)
+                    {
+                        ++this.statusOverlayTimingChunks;
+                    }
+
                     if (!chunkMeshData.hasMeshData(type))
                     {
                         continue;
@@ -1128,6 +1156,11 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                     offset[0] = (float) (chunkOrigin.getX() - x);
                     offset[1] = (float) (chunkOrigin.getY() - y);
                     offset[2] = (float) (chunkOrigin.getZ() - z);
+
+                    if (forceFallback == false && this.drawCachedStatusOverlay(fb, renderer, type, chunkMeshData, pipeline, offset, timingEnabled))
+                    {
+                        continue;
+                    }
 
                     this.drawOverlayMeshDataCameraRelative(fb, type, chunkMeshData, pipeline, offset, timingEnabled);
 
@@ -1179,6 +1212,175 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         }
     }
 
+    private boolean drawCachedStatusOverlay(RenderTarget fb, ChunkRendererSchematicVbo renderer, OverlayRenderType type,
+                                            ChunkMeshDataSchematic chunkMeshData, RenderPipeline pipeline,
+                                            float[] offset, boolean timingEnabled)
+    {
+        long startTime = timingEnabled ? System.nanoTime() : 0L;
+
+        try
+        {
+            CachedStatusOverlayMesh cached = this.getOrCreateCachedStatusOverlay(renderer, type, chunkMeshData, pipeline, timingEnabled);
+
+            if (cached == null || cached.isValid() == false)
+            {
+                return false;
+            }
+
+            cached.draw(fb, offset);
+
+            if (timingEnabled)
+            {
+                this.statusOverlayTimingCachedNanos += System.nanoTime() - startTime;
+                ++this.statusOverlayTimingCachedBuffers;
+                ++this.statusOverlayTimingCachedDraws;
+            }
+
+            return true;
+        }
+        catch (Exception err)
+        {
+            if (this.statusOverlayCacheWarningLogged == false)
+            {
+                this.statusOverlayCacheWarningLogged = true;
+                LOGGER.warn("Cached schematic status overlay draw failed; falling back to per-frame copy path: {}", err.getMessage());
+            }
+
+            return false;
+        }
+    }
+
+    @Nullable
+    private CachedStatusOverlayMesh getOrCreateCachedStatusOverlay(ChunkRendererSchematicVbo renderer, OverlayRenderType type,
+                                                                   ChunkMeshDataSchematic chunkMeshData, RenderPipeline pipeline,
+                                                                   boolean timingEnabled)
+    {
+        MeshData sourceMeshData = chunkMeshData.getMeshDataOrNull(type);
+
+        if (sourceMeshData == null || sourceMeshData.drawState().vertexCount() <= 0)
+        {
+            this.removeCachedStatusOverlay(renderer, type);
+            return null;
+        }
+
+        BlockPos chunkOrigin = renderer.getOrigin();
+        int configSignature = this.getStatusOverlayConfigSignature();
+        EnumMap<OverlayRenderType, CachedStatusOverlayMesh> rendererCache =
+                this.statusOverlayCache.computeIfAbsent(renderer, ignored -> new EnumMap<>(OverlayRenderType.class));
+        CachedStatusOverlayMesh cached = rendererCache.get(type);
+
+        if (cached != null && cached.matches(sourceMeshData, pipeline, chunkOrigin, configSignature))
+        {
+            return cached;
+        }
+
+        if (cached != null)
+        {
+            cached.closeQuietly();
+            rendererCache.remove(type);
+        }
+
+        long startTime = timingEnabled ? System.nanoTime() : 0L;
+        CachedStatusOverlayMesh newCache = this.buildCachedStatusOverlay(type, sourceMeshData, pipeline, chunkOrigin, configSignature);
+
+        if (newCache != null)
+        {
+            rendererCache.put(type, newCache);
+
+            if (timingEnabled)
+            {
+                this.statusOverlayTimingCacheBuildNanos += System.nanoTime() - startTime;
+                ++this.statusOverlayTimingCacheBuilds;
+                this.statusOverlayTimingCacheBuildVertices += newCache.vertexCount();
+            }
+        }
+
+        return newCache;
+    }
+
+    @Nullable
+    private CachedStatusOverlayMesh buildCachedStatusOverlay(OverlayRenderType type, MeshData sourceMeshData,
+                                                             RenderPipeline pipeline, BlockPos chunkOrigin,
+                                                             int configSignature)
+    {
+        RenderContext ctx = new RenderContext(() -> "litematica:schematic_status_overlay_cached/" + type.name().toLowerCase(Locale.ROOT), pipeline);
+
+        try
+        {
+            BufferBuilder builder = ctx.getBuilder();
+            int copiedVertices = this.copyOverlayMeshDataWithOffset(type, sourceMeshData, new float[] { 0.0F, 0.0F, 0.0F }, builder);
+
+            if (copiedVertices <= 0)
+            {
+                ctx.close();
+                return null;
+            }
+
+            MeshData meshData = builder.build();
+
+            if (meshData == null)
+            {
+                ctx.close();
+                return null;
+            }
+
+            try (meshData)
+            {
+                CachedStatusOverlayMesh cached =
+                        CachedStatusOverlayMesh.upload(sourceMeshData, pipeline, chunkOrigin.immutable(), type, copiedVertices, configSignature, meshData);
+                ctx.close();
+                return cached;
+            }
+        }
+        catch (Exception err)
+        {
+            try
+            {
+                ctx.close();
+            }
+            catch (Exception ignored)
+            {
+            }
+
+            throw new RuntimeException("Failed to build cached status overlay for " + type.name() + ": " + err.getMessage(), err);
+        }
+    }
+
+    private void removeCachedStatusOverlay(ChunkRendererSchematicVbo renderer, OverlayRenderType type)
+    {
+        EnumMap<OverlayRenderType, CachedStatusOverlayMesh> rendererCache = this.statusOverlayCache.get(renderer);
+
+        if (rendererCache == null)
+        {
+            return;
+        }
+
+        CachedStatusOverlayMesh cached = rendererCache.remove(type);
+
+        if (cached != null)
+        {
+            cached.closeQuietly();
+        }
+
+        if (rendererCache.isEmpty())
+        {
+            this.statusOverlayCache.remove(renderer);
+        }
+    }
+
+    private void closeStatusOverlayCache()
+    {
+        for (EnumMap<OverlayRenderType, CachedStatusOverlayMesh> rendererCache : this.statusOverlayCache.values())
+        {
+            for (CachedStatusOverlayMesh cached : rendererCache.values())
+            {
+                cached.closeQuietly();
+            }
+        }
+
+        this.statusOverlayCache.clear();
+    }
+
     private int copyOverlayMeshDataWithOffset(OverlayRenderType type, MeshData sourceMeshData, float[] offset, BufferBuilder builder)
     {
         ByteBuffer vertices = sourceMeshData.vertexBuffer().duplicate().order(ByteOrder.nativeOrder());
@@ -1221,12 +1423,48 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         return Boolean.getBoolean(STATUS_OVERLAY_TIMING_PROPERTY);
     }
 
+    private static boolean isStatusOverlayForceFallbackEnabled()
+    {
+        return Boolean.getBoolean(STATUS_OVERLAY_FORCE_FALLBACK_PROPERTY);
+    }
+
+    private int getStatusOverlayConfigSignature()
+    {
+        LayerRange range = DataManager.getRenderLayerRange();
+
+        return Objects.hash(
+                Configs.Visuals.SCHEMATIC_OVERLAY_ENABLE_SIDES.getBooleanValue(),
+                Configs.Visuals.SCHEMATIC_OVERLAY_ENABLE_OUTLINES.getBooleanValue(),
+                Configs.Visuals.SCHEMATIC_OVERLAY_RENDER_THROUGH.getBooleanValue(),
+                Configs.Visuals.ENABLE_SCHEMATIC_OVERLAY_CULLING.getBooleanValue(),
+                Configs.Visuals.OVERLAY_REDUCED_INNER_SIDES.getBooleanValue(),
+                Configs.Visuals.SCHEMATIC_OVERLAY_MODEL_SIDES.getBooleanValue(),
+                Configs.Visuals.SCHEMATIC_OVERLAY_MODEL_OUTLINE.getBooleanValue(),
+                Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH.getDoubleValue(),
+                Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH_THROUGH.getDoubleValue(),
+                Configs.Colors.SCHEMATIC_OVERLAY_COLOR_MISSING.getIntegerValue(),
+                Configs.Colors.SCHEMATIC_OVERLAY_COLOR_EXTRA.getIntegerValue(),
+                Configs.Colors.SCHEMATIC_OVERLAY_COLOR_WRONG_BLOCK.getIntegerValue(),
+                Configs.Colors.SCHEMATIC_OVERLAY_COLOR_WRONG_STATE.getIntegerValue(),
+                Configs.Colors.SCHEMATIC_OVERLAY_COLOR_DIFF_BLOCK.getIntegerValue(),
+                range.getLayerMode(),
+                range.getAxis(),
+                range.getLayerSingle(),
+                range.getLayerAbove(),
+                range.getLayerBelow(),
+                range.getLayerRangeMin(),
+                range.getLayerRangeMax(),
+                range.getLayerMin(),
+                range.getLayerMax()
+        );
+
+    }
+
     private void recordStatusOverlayTiming(long elapsedNanos, int vertices, int draws)
     {
-        this.statusOverlayTimingNanos += elapsedNanos;
-        this.statusOverlayTimingChunks += 1L;
-        this.statusOverlayTimingVertices += vertices;
-        this.statusOverlayTimingDraws += draws;
+        this.statusOverlayTimingFallbackNanos += elapsedNanos;
+        this.statusOverlayTimingVerticesCopied += vertices;
+        this.statusOverlayTimingFallbackDraws += draws;
     }
 
     private void logStatusOverlayTimingIfNeeded(boolean timingEnabled)
@@ -1248,17 +1486,147 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
             return;
         }
 
-        LOGGER.info("[StatusOverlayTiming] copyDrawMs={} chunks={} vertices={} draws={}",
-                    String.format(Locale.ROOT, "%.3f", this.statusOverlayTimingNanos / 1_000_000.0D),
+        LOGGER.info("[StatusOverlayTiming] cachedDrawMs={} cacheBuildMs={} fallbackCopyDrawMs={} overlayChunks={} verticesCopied={} cacheBuildVertices={} cachedBuffers={} cachedDrawCalls={} fallbackDrawCalls={} cacheBuilds={}",
+                    String.format(Locale.ROOT, "%.3f", this.statusOverlayTimingCachedNanos / 1_000_000.0D),
+                    String.format(Locale.ROOT, "%.3f", this.statusOverlayTimingCacheBuildNanos / 1_000_000.0D),
+                    String.format(Locale.ROOT, "%.3f", this.statusOverlayTimingFallbackNanos / 1_000_000.0D),
                     this.statusOverlayTimingChunks,
-                    this.statusOverlayTimingVertices,
-                    this.statusOverlayTimingDraws);
+                    this.statusOverlayTimingVerticesCopied,
+                    this.statusOverlayTimingCacheBuildVertices,
+                    this.statusOverlayTimingCachedBuffers,
+                    this.statusOverlayTimingCachedDraws,
+                    this.statusOverlayTimingFallbackDraws,
+                    this.statusOverlayTimingCacheBuilds);
 
         this.statusOverlayTimingLastLogTime = now;
-        this.statusOverlayTimingNanos = 0L;
+        this.statusOverlayTimingFallbackNanos = 0L;
+        this.statusOverlayTimingFallbackDraws = 0L;
+        this.statusOverlayTimingCachedNanos = 0L;
+        this.statusOverlayTimingCachedBuffers = 0L;
+        this.statusOverlayTimingCachedDraws = 0L;
+        this.statusOverlayTimingCacheBuildNanos = 0L;
+        this.statusOverlayTimingCacheBuilds = 0L;
+        this.statusOverlayTimingCacheBuildVertices = 0L;
         this.statusOverlayTimingChunks = 0L;
-        this.statusOverlayTimingVertices = 0L;
-        this.statusOverlayTimingDraws = 0L;
+        this.statusOverlayTimingVerticesCopied = 0L;
+    }
+
+    private static class CachedStatusOverlayMesh implements AutoCloseable
+    {
+        private final GpuBuffer vertexBuffer;
+        private final RenderSystem.AutoStorageIndexBuffer sequentialIndexBuffer;
+        private final MeshData sourceMeshData;
+        private final RenderPipeline pipeline;
+        private final BlockPos chunkOrigin;
+        private final OverlayRenderType type;
+        private final int indexCount;
+        private final int vertexCount;
+        private final int configSignature;
+        private boolean valid;
+
+        private CachedStatusOverlayMesh(GpuBuffer vertexBuffer, RenderSystem.AutoStorageIndexBuffer sequentialIndexBuffer,
+                                        MeshData sourceMeshData, RenderPipeline pipeline,
+                                        BlockPos chunkOrigin, OverlayRenderType type, int indexCount, int vertexCount,
+                                        int configSignature)
+        {
+            this.vertexBuffer = vertexBuffer;
+            this.sequentialIndexBuffer = sequentialIndexBuffer;
+            this.sourceMeshData = sourceMeshData;
+            this.pipeline = pipeline;
+            this.chunkOrigin = chunkOrigin;
+            this.type = type;
+            this.indexCount = indexCount;
+            this.vertexCount = vertexCount;
+            this.configSignature = configSignature;
+            this.valid = true;
+        }
+
+        private static CachedStatusOverlayMesh upload(MeshData sourceMeshData, RenderPipeline pipeline,
+                                                      BlockPos chunkOrigin, OverlayRenderType type,
+                                                      int vertexCount, int configSignature, MeshData meshData)
+        {
+            GpuDevice device = RenderSystem.getDevice();
+            int expectedSize = meshData.vertexBuffer().remaining();
+            GpuBuffer vertexBuffer = device.createBuffer(() -> "litematica:schematic_status_overlay_cached/" + type.name().toLowerCase(Locale.ROOT) + " VertexBuffer", 40, expectedSize);
+            device.createCommandEncoder().writeToBuffer(vertexBuffer.slice(), meshData.vertexBuffer());
+            RenderSystem.AutoStorageIndexBuffer sequentialIndexBuffer = RenderSystem.getSequentialBuffer(pipeline.getVertexFormatMode());
+
+            return new CachedStatusOverlayMesh(vertexBuffer, sequentialIndexBuffer, sourceMeshData, pipeline, chunkOrigin, type,
+                                               meshData.drawState().indexCount(), vertexCount, configSignature);
+        }
+
+        private boolean matches(MeshData sourceMeshData, RenderPipeline pipeline, BlockPos chunkOrigin, int configSignature)
+        {
+            return this.valid &&
+                   this.sourceMeshData == sourceMeshData &&
+                   this.pipeline == pipeline &&
+                   this.chunkOrigin.equals(chunkOrigin) &&
+                   this.configSignature == configSignature;
+        }
+
+        private boolean isValid()
+        {
+            return this.valid && this.vertexBuffer.isClosed() == false && this.indexCount > 0;
+        }
+
+        private int vertexCount()
+        {
+            return this.vertexCount;
+        }
+
+        private void draw(RenderTarget fb, float[] offset)
+        {
+            GpuDevice device = RenderSystem.getDevice();
+            GpuTextureView colorTexture = fb.getColorTextureView();
+            GpuTextureView depthTexture = fb.useDepth ? fb.getDepthTextureView() : null;
+            Matrix4f modelViewMatrix = new Matrix4f(RenderSystem.getModelViewMatrixCopy()).translate(offset[0], offset[1], offset[2]);
+            GpuBufferSlice transforms = RenderSystem.getDynamicUniforms()
+                                                    .writeTransform(modelViewMatrix,
+                                                                    new Vector4f(1.0F, 1.0F, 1.0F, 1.0F),
+                                                                    new Vector3f(0.0F, 0.0F, 0.0F),
+                                                                    new Matrix4f());
+            GpuBuffer indexBuffer = this.sequentialIndexBuffer.getBuffer(this.indexCount);
+
+            try (RenderPass pass = device.createCommandEncoder()
+                                         .createRenderPass(() -> "litematica:schematic_status_overlay_cached/" + this.type.name().toLowerCase(Locale.ROOT),
+                                                           colorTexture, OptionalInt.empty(),
+                                                           depthTexture, OptionalDouble.empty()))
+            {
+                pass.setPipeline(this.pipeline);
+
+                ScissorState scissorState = RenderSystem.getScissorStateForRenderTypeDraws();
+
+                if (scissorState.enabled())
+                {
+                    pass.enableScissor(scissorState.x(), scissorState.y(), scissorState.width(), scissorState.height());
+                }
+
+                RenderSystem.bindDefaultUniforms(pass);
+                pass.setUniform("DynamicTransforms", transforms);
+                pass.setIndexBuffer(indexBuffer, this.sequentialIndexBuffer.type());
+                pass.setVertexBuffer(0, this.vertexBuffer);
+                pass.drawIndexed(0, 0, this.indexCount, 1);
+            }
+        }
+
+        private void closeQuietly()
+        {
+            try
+            {
+                this.close();
+            }
+            catch (Exception err)
+            {
+                LOGGER.warn("Failed to close cached status overlay mesh for {}: {}", this.type.name(), err.getMessage());
+            }
+        }
+
+        @Override
+        public void close() throws Exception
+        {
+            this.valid = false;
+            this.vertexBuffer.close();
+        }
     }
 
     @Override
@@ -1789,4 +2157,76 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         BlockModelCacheSchematic.INSTANCE.onReloadResources();
         this.getBlockRenderer().reload();
 	}
+
+    private int getLayerRenderSignature()
+    {
+        LayerRange range = DataManager.getRenderLayerRange();
+
+        return Objects.hash(
+                range.getLayerMode(),
+                range.getAxis(),
+                range.getLayerSingle(),
+                range.getLayerAbove(),
+                range.getLayerBelow(),
+                range.getLayerRangeMin(),
+                range.getLayerRangeMax(),
+                range.getLayerMin(),
+                range.getLayerMax()
+        );
+    }
+
+    private void invalidateAllSchematicRenderChunksForLayerChange(int oldSignature, int newSignature)
+    {
+        int dirtyCount = 0;
+
+        this.closeStatusOverlayCache();
+
+        for (ChunkRendererSchematicVbo renderer : this.renderInfos)
+        {
+            if (renderer != null)
+            {
+                renderer.setNeedsUpdate(true);
+                this.chunksToUpdate.add(renderer);
+                ++dirtyCount;
+            }
+        }
+
+        this.needsUpdate = true;
+        this.clearWorldRenderStates();
+
+        if (Boolean.getBoolean(RENDER_MODE_INVALIDATION_PROPERTY))
+        {
+            LayerRange range = DataManager.getRenderLayerRange();
+
+            LOGGER.warn(
+                    "[Litematica] Layer render state changed ({} -> {}), mode={}, axis={}, min={}, max={}, single={}, marked {} schematic chunks dirty",
+                    oldSignature,
+                    newSignature,
+                    range.getLayerMode(),
+                    range.getAxis(),
+                    range.getLayerMin(),
+                    range.getLayerMax(),
+                    range.getLayerSingle(),
+                    dirtyCount
+            );
+        }
+    }
+
+    private void checkLayerRenderStateChanged()
+    {
+        int currentSignature = this.getLayerRenderSignature();
+
+        if (this.lastLayerRenderSignature == Integer.MIN_VALUE)
+        {
+            this.lastLayerRenderSignature = currentSignature;
+            return;
+        }
+
+        if (currentSignature != this.lastLayerRenderSignature)
+        {
+            int oldSignature = this.lastLayerRenderSignature;
+            this.lastLayerRenderSignature = currentSignature;
+            this.invalidateAllSchematicRenderChunksForLayerChange(oldSignature, currentSignature);
+        }
+    }
 }

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
@@ -46,6 +46,7 @@ import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.state.level.LevelRenderState;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.ARGB;
 import net.minecraft.util.RandomSource;
@@ -79,6 +80,7 @@ import fi.dy.masa.malilib.render.uniform.ChunkFixUniform;
 import fi.dy.masa.malilib.util.EntityUtils;
 import fi.dy.masa.malilib.util.LayerRange;
 import fi.dy.masa.malilib.util.MathUtils;
+import fi.dy.masa.malilib.util.data.Color4f;
 import fi.dy.masa.litematica.Litematica;
 import fi.dy.masa.litematica.Reference;
 import fi.dy.masa.litematica.config.Configs;
@@ -86,6 +88,7 @@ import fi.dy.masa.litematica.config.Hotkeys;
 import fi.dy.masa.litematica.data.DataManager;
 import fi.dy.masa.litematica.mixin.entity.IMixinEntity;
 import fi.dy.masa.litematica.render.IWorldSchematicRenderer;
+import fi.dy.masa.litematica.schematic.placement.SchematicPlacement;
 import fi.dy.masa.litematica.util.*;
 import fi.dy.masa.litematica.world.ChunkSchematic;
 import fi.dy.masa.litematica.world.ChunkSchematicState;
@@ -129,6 +132,14 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     private double lastTranslucentSortZ;
     private boolean needsUpdate;
     private boolean shouldDraw;
+    private int diagVisibleChunks;
+    private int diagPreparedChunks;
+    private int diagDrawCallsSolid;
+    private int diagDrawCallsCutout;
+    private int diagDrawCallsTranslucent;
+    private int diagOverlayOutlineDrawCalls;
+    private int diagOverlayQuadDrawCalls;
+    private long diagLastOverlayLogTime;
 
     public WorldRendererSchematic(Minecraft mc)
     {
@@ -202,6 +213,41 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         }
 
         return count;
+    }
+
+    public int getDiagVisibleChunks()
+    {
+        return this.diagVisibleChunks;
+    }
+
+    public int getDiagPreparedChunks()
+    {
+        return this.diagPreparedChunks;
+    }
+
+    public int getDiagDrawCallsSolid()
+    {
+        return this.diagDrawCallsSolid;
+    }
+
+    public int getDiagDrawCallsCutout()
+    {
+        return this.diagDrawCallsCutout;
+    }
+
+    public int getDiagDrawCallsTranslucent()
+    {
+        return this.diagDrawCallsTranslucent;
+    }
+
+    public int getDiagOverlayOutlineDrawCalls()
+    {
+        return this.diagOverlayOutlineDrawCalls;
+    }
+
+    public int getDiagOverlayQuadDrawCalls()
+    {
+        return this.diagOverlayQuadDrawCalls;
     }
 
     @Override
@@ -296,6 +342,12 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     protected GpuBufferSlice getEmptyFogBuffer()
     {
         return this.getFogRenderer().getBuffer(FogRenderer.FogMode.NONE);
+    }
+
+    private static boolean isEntityType(Entity entity, String path)
+    {
+        Identifier id = BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType());
+        return id != null && id.equals(Identifier.withDefaultNamespace(path));
     }
 
     @Override
@@ -416,6 +468,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 //        LOGGER.warn("[WorldRenderer] setupTerrain()");
         this.profiler = profiler;
         profiler.push("setup_terrain");
+        this.diagVisibleChunks = 0;
 
         if (this.chunkRendererDispatcher == null ||
             this.mc.options.renderDistance().get() + 2 != this.renderDistanceChunks)
@@ -528,6 +581,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 //                        }
 
                         this.renderInfos.add(chunkRenderer);
+                        ++this.diagVisibleChunks;
                     }
                 }
 
@@ -546,6 +600,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         {
             if (chunkRendererTmp.needsUpdate() || set.contains(chunkRendererTmp))
             {
+                set.remove(chunkRendererTmp);
                 this.needsUpdate = true;
                 BlockPos pos = chunkRendererTmp.getOrigin().offset(8, 8, 8);
                 boolean isNear = pos.distSqr(viewPos) < 1024.0D;
@@ -570,12 +625,8 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
             }
         }
 
+        // Preserve pending chunks that were not in the current visible set.
         this.chunksToUpdate.addAll(set);
-
-        if (Reference.DEBUG_MODE && !this.chunksToUpdate.isEmpty())
-        {
-            Litematica.LOGGER.warn("[WorldRenderer] setupTerrain / chunksToUpdate: {}", this.chunksToUpdate.size());
-        }
 
 		this.clearWorldRenderStates();
 
@@ -677,6 +728,10 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         this.profiler = profiler;
 //        RenderSystem.assertOnRenderThread();
         profiler.push("layer_multi_phase");
+        this.diagPreparedChunks = this.renderInfos.size();
+        this.diagDrawCallsSolid = 0;
+        this.diagDrawCallsCutout = 0;
+        this.diagDrawCallsTranslucent = 0;
 
 	    List<DynamicUniforms.Transform> transformValues = new ArrayList<>();
 //        EnumMap<ChunkSectionLayer, Int2ObjectOpenHashMap<List<RenderPass.Draw<GpuBufferSlice[]>>>> renderMap = new EnumMap<>(ChunkSectionLayer.class);
@@ -867,6 +922,9 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
         if (startedDrawing)
         {
+            this.diagDrawCallsSolid = renderMap.get(ChunkSectionLayer.SOLID).size();
+            this.diagDrawCallsCutout = renderMap.get(ChunkSectionLayer.CUTOUT).size();
+            this.diagDrawCallsTranslucent = renderMap.get(ChunkSectionLayer.TRANSLUCENT).size();
             profiler.popPush("fill_uniforms");
             this.getSchematicRenderState().chunkFixUniform.fillBuffer(atlasWidth, atlasHeight, 1.0f);
             GpuBufferSlice[] transformSlices = RenderSystem.getDynamicUniforms()
@@ -1069,8 +1127,11 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     {
 //        LOGGER.warn("[WorldRenderer] renderBlockOverlays()");
         this.profiler = profiler;
-        this.renderBlockOverlay(OverlayRenderType.OUTLINE, camera, lineWidth, profiler);
+        // Draw filled status faces first so the final colored outlines remain visible.
         this.renderBlockOverlay(OverlayRenderType.QUAD, camera, lineWidth, profiler);
+        this.renderBlockOverlay(OverlayRenderType.OUTLINE, camera, lineWidth, profiler);
+
+        this.logOverlayDiagnostics();
     }
 
     protected void renderBlockOverlay(OverlayRenderType type, Camera camera, float lineWidth, ProfilerFiller profiler)
@@ -1078,6 +1139,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 //        LOGGER.warn("[WorldRenderer] renderBlockOverlay() [{}]", type.name());
         profiler.push("overlay_" + type.name());
         this.profiler = profiler;
+        int drawCount = 0;
 
         Vec3 cameraPos = camera.position();
         double x = cameraPos.x;
@@ -1087,9 +1149,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         boolean renderThrough = Configs.Visuals.SCHEMATIC_OVERLAY_RENDER_THROUGH.getBooleanValue() || Hotkeys.RENDER_OVERLAY_THROUGH_BLOCKS.getKeybind().isKeybindHeld();
         RenderPipeline pipeline = renderThrough ? type.getRenderThrough() : type.getPipeline();
 
-        float[] offset = new float[]{0.3f, 0.0f, 0.6f};
-
-        Matrix4fStack matrix4fStack = RenderSystem.getModelViewStack();
+        float[] offset = new float[3];
 
         profiler.popPush("overlay_iterate");
         this.profiler = profiler;
@@ -1114,15 +1174,123 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                         continue;
                     }
 
-                    matrix4fStack.pushMatrix();
-                    matrix4fStack.translate((float) (chunkOrigin.getX() - x), (float) (chunkOrigin.getY() - y), (float) (chunkOrigin.getZ() - z));
-                    this.drawOverlayInternal(pipeline, buffers, -1, offset, false, false);
-                    matrix4fStack.popMatrix();
+                    offset[0] = (float) (chunkOrigin.getX() - x);
+                    offset[1] = (float) (chunkOrigin.getY() - y);
+                    offset[2] = (float) (chunkOrigin.getZ() - z);
+                    this.drawOverlayInternal(pipeline, buffers, -1, offset, false, true);
+                    ++drawCount;
                 }
             }
         }
 
+        if (type == OverlayRenderType.OUTLINE)
+        {
+            this.diagOverlayOutlineDrawCalls = drawCount;
+        }
+        else if (type == OverlayRenderType.QUAD)
+        {
+            this.diagOverlayQuadDrawCalls = drawCount;
+        }
+
         profiler.pop();
+    }
+
+    private void logOverlayDiagnostics()
+    {
+        if (!Boolean.getBoolean("litematica.debug.schematicOverlay"))
+        {
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+
+        if (now - this.diagLastOverlayLogTime < 5000L)
+        {
+            return;
+        }
+
+        this.diagLastOverlayLogTime = now;
+        ChunkRendererSchematicVbo.OverlayBuildStats stats = new ChunkRendererSchematicVbo.OverlayBuildStats();
+
+        for (ChunkRendererSchematicVbo renderer : this.renderInfos)
+        {
+            renderer.getOverlayBuildStats().mergeInto(stats);
+        }
+
+        SchematicPlacement selected = DataManager.getSchematicPlacementManager().getSelectedSchematicPlacement();
+        List<SchematicPlacement> placements = DataManager.getSchematicPlacementManager().getAllSchematicsPlacements();
+        String placement = selected != null ?
+                           String.format("%s/%s", selected.getName(), selected.getHashId()) :
+                           "<none selected>";
+        boolean renderThrough = Configs.Visuals.SCHEMATIC_OVERLAY_RENDER_THROUGH.getBooleanValue() || Hotkeys.RENDER_OVERLAY_THROUGH_BLOCKS.getKeybind().isKeybindHeld();
+        RenderPipeline quadPipeline = renderThrough ? OverlayRenderType.QUAD.getRenderThrough() : OverlayRenderType.QUAD.getPipeline();
+        RenderPipeline outlinePipeline = renderThrough ? OverlayRenderType.OUTLINE.getRenderThrough() : OverlayRenderType.OUTLINE.getPipeline();
+
+        LOGGER.info("[OverlayDiag] placement={} placementCount={} enableOverlay={} sides={} outlines={} renderThrough={} forcedColors={} verifierOverlay={} overlayPassOrder='ghost terrain before status overlay; status quads before status outlines'",
+                    placement,
+                    placements.size(),
+                    Configs.Visuals.ENABLE_SCHEMATIC_OVERLAY.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_ENABLE_SIDES.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_ENABLE_OUTLINES.getBooleanValue(),
+                    renderThrough,
+                    Boolean.getBoolean("litematica.debug.schematicOverlay.forceColors"),
+                    Configs.InfoOverlays.VERIFIER_OVERLAY_ENABLED.getBooleanValue());
+        LOGGER.info("[OverlayDiag] overlayOptions culling={} reducedInnerSides={} modelSides={} modelOutline={} typeMissing={} typeExtra={} typeWrongBlock={} typeWrongState={} typeDiffBlock={} outlineWidth={} outlineWidthThrough={} configuredColors missing={} extra={} wrongBlock={} wrongState={} diffBlock={}",
+                    Configs.Visuals.ENABLE_SCHEMATIC_OVERLAY_CULLING.getBooleanValue(),
+                    Configs.Visuals.OVERLAY_REDUCED_INNER_SIDES.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_MODEL_SIDES.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_MODEL_OUTLINE.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_MISSING.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_EXTRA.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_WRONG_BLOCK.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_WRONG_STATE.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_DIFF_BLOCK.getBooleanValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH.getDoubleValue(),
+                    Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH_THROUGH.getDoubleValue(),
+                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_MISSING.getColor()),
+                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_EXTRA.getColor()),
+                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_WRONG_BLOCK.getColor()),
+                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_WRONG_STATE.getColor()),
+                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_DIFF_BLOCK.getColor()));
+        LOGGER.info("[OverlayDiag] statusCounts totalChecked={} {} colors={}",
+                    stats.getTotalChecked(),
+                    stats.getTypeCountsString(),
+                    stats.getColorCountsString());
+        LOGGER.info("[OverlayDiag] meshVertices quads={} outlines={} drawCalls quads={} outlines={} visibleChunks={} solid={} cutout={} translucent={}",
+                    stats.getQuadVertices(),
+                    stats.getOutlineVertices(),
+                    this.diagOverlayQuadDrawCalls,
+                    this.diagOverlayOutlineDrawCalls,
+                    this.diagVisibleChunks,
+                    this.diagDrawCallsSolid,
+                    this.diagDrawCallsCutout,
+                    this.diagDrawCallsTranslucent);
+        LOGGER.info("[OverlayDiag] quadPipeline location={} mode={} format={} vertexShader={} fragmentShader={} depth={} colorTarget={}",
+                    quadPipeline.getLocation(),
+                    quadPipeline.getVertexFormatMode(),
+                    quadPipeline.getVertexFormat(),
+                    quadPipeline.getVertexShader(),
+                    quadPipeline.getFragmentShader(),
+                    quadPipeline.getDepthStencilState(),
+                    quadPipeline.getColorTargetState());
+        LOGGER.info("[OverlayDiag] outlinePipeline location={} mode={} format={} vertexShader={} fragmentShader={} depth={} colorTarget={}",
+                    outlinePipeline.getLocation(),
+                    outlinePipeline.getVertexFormatMode(),
+                    outlinePipeline.getVertexFormat(),
+                    outlinePipeline.getVertexShader(),
+                    outlinePipeline.getFragmentShader(),
+                    outlinePipeline.getDepthStencilState(),
+                    outlinePipeline.getColorTargetState());
+    }
+
+    private static String colorToHex(Color4f color)
+    {
+        int a = Math.round(color.a * 255.0f) & 0xFF;
+        int r = Math.round(color.r * 255.0f) & 0xFF;
+        int g = Math.round(color.g * 255.0f) & 0xFF;
+        int b = Math.round(color.b * 255.0f) & 0xFF;
+
+        return String.format("#%02X%02X%02X%02X", a, r, g, b);
     }
 
     @Override
@@ -1241,7 +1409,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
             GpuBufferSlice gpuSlice = RenderSystem.getDynamicUniforms()
                                                   .writeTransform(
-                                                          RenderSystem.getModelViewMatrix(),
+                                                          RenderSystem.getModelViewMatrixCopy(),
                                                           colorMod,
                                                           modelOffset,
                                                           texMatrix);
@@ -1267,6 +1435,11 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Nullable
     public BlockStateModel getModelForState(BlockState state)
     {
+        if (state.isAir())
+        {
+            return null;
+        }
+
         return BlockModelCacheSchematic.INSTANCE.fetchBlockStateModel(state);
     }
 
@@ -1380,7 +1553,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
                     if (entityTmp instanceof Avatar avatar)
                     {
-                        if (avatar.getType().equals(EntityType.MANNEQUIN))
+                        if (isEntityType(avatar, "mannequin"))
                         {
                             try
                             {
@@ -1405,7 +1578,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                                 Litematica.LOGGER.error("Exception rendering Mannequin [{}]; {}", avatar.getClass().getName(), ex.getLocalizedMessage());
                             }
                         }
-                        else if (avatar.getType().equals(EntityType.PLAYER))
+                        else if (isEntityType(avatar, "player"))
                         {
                             try
                             {
@@ -1564,7 +1737,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                         {
                             matrices.pushPose();
                             matrices.translate(pos.getX() - cameraX, pos.getY() - cameraY, pos.getZ() - cameraZ);
-                            BlockEntityRenderState state = this.getBlockEntityRenderer().tryExtractRenderState(te, tickProgress, null);
+                            BlockEntityRenderState state = this.getBlockEntityRenderer().tryExtractRenderState(te, tickProgress, null, false);
                             this.getSchematicRenderState().blockEntityStates.add(state);
                             // Ignore crumbling, because there is no point in the Schem World.
                             matrices.popPose();
@@ -1593,7 +1766,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                         {
                             matrices.pushPose();
                             matrices.translate(pos.getX() - cameraX, pos.getY() - cameraY, pos.getZ() - cameraZ);
-                            BlockEntityRenderState state = this.getBlockEntityRenderer().tryExtractRenderState(te, tickProgress, null);
+                            BlockEntityRenderState state = this.getBlockEntityRenderer().tryExtractRenderState(te, tickProgress, null, true);
                             this.getSchematicRenderState().blockEntityStates.add(state);
                             // Ignore crumbling, because there is no point in the Schem World.
                             matrices.popPose();

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
@@ -1,10 +1,15 @@
 package fi.dy.masa.litematica.render.schematic;
 
 import java.lang.Math;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.*;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.MeshData;
+import fi.dy.masa.malilib.render.RenderContext;
 import org.apache.logging.log4j.Logger;
 import org.joml.*;
 
@@ -80,7 +85,6 @@ import fi.dy.masa.malilib.render.uniform.ChunkFixUniform;
 import fi.dy.masa.malilib.util.EntityUtils;
 import fi.dy.masa.malilib.util.LayerRange;
 import fi.dy.masa.malilib.util.MathUtils;
-import fi.dy.masa.malilib.util.data.Color4f;
 import fi.dy.masa.litematica.Litematica;
 import fi.dy.masa.litematica.Reference;
 import fi.dy.masa.litematica.config.Configs;
@@ -96,6 +100,8 @@ import fi.dy.masa.litematica.world.WorldSchematic;
 
 public class WorldRendererSchematic implements IWorldSchematicRenderer
 {
+    private static final String STATUS_OVERLAY_TIMING_PROPERTY = "litematica.debug.schematicOverlayTiming";
+    private static final long STATUS_OVERLAY_TIMING_LOG_INTERVAL_MS = 5000L;
     private static final Logger LOGGER = Litematica.LOGGER;
     private final Minecraft mc;
     private final List<ChunkRendererSchematicVbo> renderInfos;
@@ -126,20 +132,17 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     private int countEntitiesTotal;
     private int countEntitiesRendered;
     private int countEntitiesHidden;
+    private long statusOverlayTimingLastLogTime;
+    private long statusOverlayTimingNanos;
+    private long statusOverlayTimingChunks;
+    private long statusOverlayTimingVertices;
+    private long statusOverlayTimingDraws;
 
     private double lastTranslucentSortX;
     private double lastTranslucentSortY;
     private double lastTranslucentSortZ;
     private boolean needsUpdate;
     private boolean shouldDraw;
-    private int diagVisibleChunks;
-    private int diagPreparedChunks;
-    private int diagDrawCallsSolid;
-    private int diagDrawCallsCutout;
-    private int diagDrawCallsTranslucent;
-    private int diagOverlayOutlineDrawCalls;
-    private int diagOverlayQuadDrawCalls;
-    private long diagLastOverlayLogTime;
 
     public WorldRendererSchematic(Minecraft mc)
     {
@@ -213,41 +216,6 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         }
 
         return count;
-    }
-
-    public int getDiagVisibleChunks()
-    {
-        return this.diagVisibleChunks;
-    }
-
-    public int getDiagPreparedChunks()
-    {
-        return this.diagPreparedChunks;
-    }
-
-    public int getDiagDrawCallsSolid()
-    {
-        return this.diagDrawCallsSolid;
-    }
-
-    public int getDiagDrawCallsCutout()
-    {
-        return this.diagDrawCallsCutout;
-    }
-
-    public int getDiagDrawCallsTranslucent()
-    {
-        return this.diagDrawCallsTranslucent;
-    }
-
-    public int getDiagOverlayOutlineDrawCalls()
-    {
-        return this.diagOverlayOutlineDrawCalls;
-    }
-
-    public int getDiagOverlayQuadDrawCalls()
-    {
-        return this.diagOverlayQuadDrawCalls;
     }
 
     @Override
@@ -468,7 +436,6 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 //        LOGGER.warn("[WorldRenderer] setupTerrain()");
         this.profiler = profiler;
         profiler.push("setup_terrain");
-        this.diagVisibleChunks = 0;
 
         if (this.chunkRendererDispatcher == null ||
             this.mc.options.renderDistance().get() + 2 != this.renderDistanceChunks)
@@ -581,7 +548,6 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 //                        }
 
                         this.renderInfos.add(chunkRenderer);
-                        ++this.diagVisibleChunks;
                     }
                 }
 
@@ -687,10 +653,6 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
                 index++;
             }
 
-            if (Reference.DEBUG_MODE && index > 0)
-            {
-                LOGGER.info("[WorldRenderer] updateChunks(): {} Chunks updated.", index);
-            }
         }
 
         profiler.pop();
@@ -728,10 +690,6 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         this.profiler = profiler;
 //        RenderSystem.assertOnRenderThread();
         profiler.push("layer_multi_phase");
-        this.diagPreparedChunks = this.renderInfos.size();
-        this.diagDrawCallsSolid = 0;
-        this.diagDrawCallsCutout = 0;
-        this.diagDrawCallsTranslucent = 0;
 
 	    List<DynamicUniforms.Transform> transformValues = new ArrayList<>();
 //        EnumMap<ChunkSectionLayer, Int2ObjectOpenHashMap<List<RenderPass.Draw<GpuBufferSlice[]>>>> renderMap = new EnumMap<>(ChunkSectionLayer.class);
@@ -922,9 +880,6 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
         if (startedDrawing)
         {
-            this.diagDrawCallsSolid = renderMap.get(ChunkSectionLayer.SOLID).size();
-            this.diagDrawCallsCutout = renderMap.get(ChunkSectionLayer.CUTOUT).size();
-            this.diagDrawCallsTranslucent = renderMap.get(ChunkSectionLayer.TRANSLUCENT).size();
             profiler.popPush("fill_uniforms");
             this.getSchematicRenderState().chunkFixUniform.fillBuffer(atlasWidth, atlasHeight, 1.0f);
             GpuBufferSlice[] transformSlices = RenderSystem.getDynamicUniforms()
@@ -949,6 +904,7 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     @Override
     public void drawBlockLayerGroup(ChunkSectionLayerGroup group, @Nullable GpuSampler sampler)
     {
+
 //        LOGGER.warn("[WorldRenderer] drawBlockLayerGroup() [{}]", group.label());
         if (this.getSchematicRenderState().hasBatchDraw() && this.shouldDraw)
         {
@@ -1123,24 +1079,21 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
     }
 
     @Override
-    public void renderBlockOverlays(Camera camera, float lineWidth, ProfilerFiller profiler)
+    public void renderBlockOverlays(RenderTarget fb, Camera camera, ProfilerFiller profiler)
     {
-//        LOGGER.warn("[WorldRenderer] renderBlockOverlays()");
         this.profiler = profiler;
-        // Draw filled status faces first so the final colored outlines remain visible.
-        this.renderBlockOverlay(OverlayRenderType.QUAD, camera, lineWidth, profiler);
-        this.renderBlockOverlay(OverlayRenderType.OUTLINE, camera, lineWidth, profiler);
+        boolean timingEnabled = isStatusOverlayTimingEnabled();
 
-        this.logOverlayDiagnostics();
+        // Draw filled status faces first so the final colored outlines remain visible.
+        this.renderBlockOverlay(fb, OverlayRenderType.QUAD, camera, profiler, timingEnabled);
+        this.renderBlockOverlay(fb, OverlayRenderType.OUTLINE, camera, profiler, timingEnabled);
+        this.logStatusOverlayTimingIfNeeded(timingEnabled);
     }
 
-    protected void renderBlockOverlay(OverlayRenderType type, Camera camera, float lineWidth, ProfilerFiller profiler)
+    protected void renderBlockOverlay(RenderTarget fb, OverlayRenderType type, Camera camera, ProfilerFiller profiler, boolean timingEnabled)
     {
-//        LOGGER.warn("[WorldRenderer] renderBlockOverlay() [{}]", type.name());
         profiler.push("overlay_" + type.name());
         this.profiler = profiler;
-        int drawCount = 0;
-
         Vec3 cameraPos = camera.position();
         double x = cameraPos.x;
         double y = cameraPos.y;
@@ -1165,132 +1118,147 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
 
                 if (!compiledChunk.isOverlayTypeEmpty(type))
                 {
-                    ChunkRenderBuffers buffers = renderer.getBuffersOrNull(type);
                     BlockPos chunkOrigin = renderer.getOrigin();
 
-                    if (buffers == null || buffers.isClosed() || !chunkMeshData.hasMeshData(type))
+                    if (!chunkMeshData.hasMeshData(type))
                     {
-//                        LOGGER.error("Overlay [{}], ChunkOrigin [{}], NO BUFFERS", type.name(), chunkOrigin.toShortString());
                         continue;
                     }
 
                     offset[0] = (float) (chunkOrigin.getX() - x);
                     offset[1] = (float) (chunkOrigin.getY() - y);
                     offset[2] = (float) (chunkOrigin.getZ() - z);
-                    this.drawOverlayInternal(pipeline, buffers, -1, offset, false, true);
-                    ++drawCount;
+
+                    this.drawOverlayMeshDataCameraRelative(fb, type, chunkMeshData, pipeline, offset, timingEnabled);
+
                 }
             }
-        }
-
-        if (type == OverlayRenderType.OUTLINE)
-        {
-            this.diagOverlayOutlineDrawCalls = drawCount;
-        }
-        else if (type == OverlayRenderType.QUAD)
-        {
-            this.diagOverlayQuadDrawCalls = drawCount;
         }
 
         profiler.pop();
     }
 
-    private void logOverlayDiagnostics()
+    private void drawOverlayMeshDataCameraRelative(RenderTarget fb, OverlayRenderType type, ChunkMeshDataSchematic chunkMeshData,
+                                                   RenderPipeline pipeline, float[] offset, boolean timingEnabled)
     {
-        if (!Boolean.getBoolean("litematica.debug.schematicOverlay"))
+        MeshData sourceMeshData = chunkMeshData.getMeshDataOrNull(type);
+
+        if (sourceMeshData == null)
+        {
+            return;
+        }
+
+        long startTime = timingEnabled ? System.nanoTime() : 0L;
+        int copiedVertices = 0;
+        int draws = 0;
+
+        try (RenderContext ctx = new RenderContext(() -> "litematica:schematic_status_overlay/" + type.name().toLowerCase(Locale.ROOT), pipeline))
+        {
+            BufferBuilder builder = ctx.getBuilder();
+            copiedVertices = this.copyOverlayMeshDataWithOffset(type, sourceMeshData, offset, builder);
+
+            try (MeshData meshData = builder.build())
+            {
+                if (meshData != null)
+                {
+                    ctx.draw(fb, meshData, false, false, false);
+                    draws = 1;
+                }
+            }
+        }
+        catch (Exception err)
+        {
+            LOGGER.warn("Schematic status overlay draw failed for {}: {}", type.name(), err.getMessage());
+        }
+        finally
+        {
+            if (timingEnabled)
+            {
+                this.recordStatusOverlayTiming(System.nanoTime() - startTime, copiedVertices, draws);
+            }
+        }
+    }
+
+    private int copyOverlayMeshDataWithOffset(OverlayRenderType type, MeshData sourceMeshData, float[] offset, BufferBuilder builder)
+    {
+        ByteBuffer vertices = sourceMeshData.vertexBuffer().duplicate().order(ByteOrder.nativeOrder());
+        int vertexSize = type.getVertexFormat().getVertexSize();
+        int vertexCount = sourceMeshData.drawState().vertexCount();
+        int copiedVertices = 0;
+
+        for (int i = 0; i < vertexCount; ++i)
+        {
+            int base = vertices.position() + i * vertexSize;
+
+            if (base + 16 > vertices.limit())
+            {
+                break;
+            }
+
+            float vx = vertices.getFloat(base) + offset[0];
+            float vy = vertices.getFloat(base + 4) + offset[1];
+            float vz = vertices.getFloat(base + 8) + offset[2];
+            int color = ARGB.toABGR(vertices.getInt(base + 12));
+
+            if (type == OverlayRenderType.OUTLINE)
+            {
+                float lineWidth = vertexSize >= 20 && base + 20 <= vertices.limit() ? vertices.getFloat(base + 16) : 1.0F;
+                builder.addVertex(vx, vy, vz).setColor(color).setLineWidth(lineWidth);
+            }
+            else
+            {
+                builder.addVertex(vx, vy, vz).setColor(color);
+            }
+
+            ++copiedVertices;
+        }
+
+        return copiedVertices;
+    }
+
+    private static boolean isStatusOverlayTimingEnabled()
+    {
+        return Boolean.getBoolean(STATUS_OVERLAY_TIMING_PROPERTY);
+    }
+
+    private void recordStatusOverlayTiming(long elapsedNanos, int vertices, int draws)
+    {
+        this.statusOverlayTimingNanos += elapsedNanos;
+        this.statusOverlayTimingChunks += 1L;
+        this.statusOverlayTimingVertices += vertices;
+        this.statusOverlayTimingDraws += draws;
+    }
+
+    private void logStatusOverlayTimingIfNeeded(boolean timingEnabled)
+    {
+        if (!timingEnabled)
         {
             return;
         }
 
         long now = System.currentTimeMillis();
 
-        if (now - this.diagLastOverlayLogTime < 5000L)
+        if (this.statusOverlayTimingLastLogTime == 0L)
+        {
+            this.statusOverlayTimingLastLogTime = now;
+        }
+
+        if (now - this.statusOverlayTimingLastLogTime < STATUS_OVERLAY_TIMING_LOG_INTERVAL_MS)
         {
             return;
         }
 
-        this.diagLastOverlayLogTime = now;
-        ChunkRendererSchematicVbo.OverlayBuildStats stats = new ChunkRendererSchematicVbo.OverlayBuildStats();
+        LOGGER.info("[StatusOverlayTiming] copyDrawMs={} chunks={} vertices={} draws={}",
+                    String.format(Locale.ROOT, "%.3f", this.statusOverlayTimingNanos / 1_000_000.0D),
+                    this.statusOverlayTimingChunks,
+                    this.statusOverlayTimingVertices,
+                    this.statusOverlayTimingDraws);
 
-        for (ChunkRendererSchematicVbo renderer : this.renderInfos)
-        {
-            renderer.getOverlayBuildStats().mergeInto(stats);
-        }
-
-        SchematicPlacement selected = DataManager.getSchematicPlacementManager().getSelectedSchematicPlacement();
-        List<SchematicPlacement> placements = DataManager.getSchematicPlacementManager().getAllSchematicsPlacements();
-        String placement = selected != null ?
-                           String.format("%s/%s", selected.getName(), selected.getHashId()) :
-                           "<none selected>";
-        boolean renderThrough = Configs.Visuals.SCHEMATIC_OVERLAY_RENDER_THROUGH.getBooleanValue() || Hotkeys.RENDER_OVERLAY_THROUGH_BLOCKS.getKeybind().isKeybindHeld();
-        RenderPipeline quadPipeline = renderThrough ? OverlayRenderType.QUAD.getRenderThrough() : OverlayRenderType.QUAD.getPipeline();
-        RenderPipeline outlinePipeline = renderThrough ? OverlayRenderType.OUTLINE.getRenderThrough() : OverlayRenderType.OUTLINE.getPipeline();
-
-        LOGGER.info("[OverlayDiag] placement={} placementCount={} enableOverlay={} sides={} outlines={} renderThrough={} forcedColors={} verifierOverlay={} overlayPassOrder='ghost terrain before status overlay; status quads before status outlines'",
-                    placement,
-                    placements.size(),
-                    Configs.Visuals.ENABLE_SCHEMATIC_OVERLAY.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_ENABLE_SIDES.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_ENABLE_OUTLINES.getBooleanValue(),
-                    renderThrough,
-                    Boolean.getBoolean("litematica.debug.schematicOverlay.forceColors"),
-                    Configs.InfoOverlays.VERIFIER_OVERLAY_ENABLED.getBooleanValue());
-        LOGGER.info("[OverlayDiag] overlayOptions culling={} reducedInnerSides={} modelSides={} modelOutline={} typeMissing={} typeExtra={} typeWrongBlock={} typeWrongState={} typeDiffBlock={} outlineWidth={} outlineWidthThrough={} configuredColors missing={} extra={} wrongBlock={} wrongState={} diffBlock={}",
-                    Configs.Visuals.ENABLE_SCHEMATIC_OVERLAY_CULLING.getBooleanValue(),
-                    Configs.Visuals.OVERLAY_REDUCED_INNER_SIDES.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_MODEL_SIDES.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_MODEL_OUTLINE.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_MISSING.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_EXTRA.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_WRONG_BLOCK.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_WRONG_STATE.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_TYPE_DIFF_BLOCK.getBooleanValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH.getDoubleValue(),
-                    Configs.Visuals.SCHEMATIC_OVERLAY_OUTLINE_WIDTH_THROUGH.getDoubleValue(),
-                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_MISSING.getColor()),
-                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_EXTRA.getColor()),
-                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_WRONG_BLOCK.getColor()),
-                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_WRONG_STATE.getColor()),
-                    colorToHex(Configs.Colors.SCHEMATIC_OVERLAY_COLOR_DIFF_BLOCK.getColor()));
-        LOGGER.info("[OverlayDiag] statusCounts totalChecked={} {} colors={}",
-                    stats.getTotalChecked(),
-                    stats.getTypeCountsString(),
-                    stats.getColorCountsString());
-        LOGGER.info("[OverlayDiag] meshVertices quads={} outlines={} drawCalls quads={} outlines={} visibleChunks={} solid={} cutout={} translucent={}",
-                    stats.getQuadVertices(),
-                    stats.getOutlineVertices(),
-                    this.diagOverlayQuadDrawCalls,
-                    this.diagOverlayOutlineDrawCalls,
-                    this.diagVisibleChunks,
-                    this.diagDrawCallsSolid,
-                    this.diagDrawCallsCutout,
-                    this.diagDrawCallsTranslucent);
-        LOGGER.info("[OverlayDiag] quadPipeline location={} mode={} format={} vertexShader={} fragmentShader={} depth={} colorTarget={}",
-                    quadPipeline.getLocation(),
-                    quadPipeline.getVertexFormatMode(),
-                    quadPipeline.getVertexFormat(),
-                    quadPipeline.getVertexShader(),
-                    quadPipeline.getFragmentShader(),
-                    quadPipeline.getDepthStencilState(),
-                    quadPipeline.getColorTargetState());
-        LOGGER.info("[OverlayDiag] outlinePipeline location={} mode={} format={} vertexShader={} fragmentShader={} depth={} colorTarget={}",
-                    outlinePipeline.getLocation(),
-                    outlinePipeline.getVertexFormatMode(),
-                    outlinePipeline.getVertexFormat(),
-                    outlinePipeline.getVertexShader(),
-                    outlinePipeline.getFragmentShader(),
-                    outlinePipeline.getDepthStencilState(),
-                    outlinePipeline.getColorTargetState());
-    }
-
-    private static String colorToHex(Color4f color)
-    {
-        int a = Math.round(color.a * 255.0f) & 0xFF;
-        int r = Math.round(color.r * 255.0f) & 0xFF;
-        int g = Math.round(color.g * 255.0f) & 0xFF;
-        int b = Math.round(color.b * 255.0f) & 0xFF;
-
-        return String.format("#%02X%02X%02X%02X", a, r, g, b);
+        this.statusOverlayTimingLastLogTime = now;
+        this.statusOverlayTimingNanos = 0L;
+        this.statusOverlayTimingChunks = 0L;
+        this.statusOverlayTimingVertices = 0L;
+        this.statusOverlayTimingDraws = 0L;
     }
 
     @Override
@@ -1356,79 +1324,6 @@ public class WorldRendererSchematic implements IWorldSchematicRenderer
         }
 
         return false;
-    }
-
-    // Probably not the most efficient way; but it works.
-    private void drawOverlayInternal(RenderPipeline pipeline,
-                                     ChunkRenderBuffers buffers,
-                                     int color, float[] offset,
-                                     boolean useColor, boolean useOffset) throws RuntimeException
-    {
-        if (RenderSystem.isOnRenderThread())
-        {
-            Vector4f colorMod = new Vector4f(1f, 1f, 1f, 1f);
-            Vector3f modelOffset = new Vector3f();
-            Matrix4f texMatrix = new Matrix4f();
-
-            if (useOffset)
-            {
-                modelOffset.set(offset);
-            }
-
-            if (useColor)
-            {
-                float[] rgba = {ARGB.redFloat(color), ARGB.greenFloat(color), ARGB.blueFloat(color), ARGB.alphaFloat(color)};
-                colorMod.set(rgba);
-            }
-
-            RenderTarget mainFb = RenderUtils.fb();
-            GpuTextureView texture1 = mainFb.getColorTextureView();
-            GpuTextureView texture2 = mainFb.useDepth ? mainFb.getDepthTextureView() : null;
-            RenderSystem.AutoStorageIndexBuffer shapeIndexBuffer = RenderSystem.getSequentialBuffer(pipeline.getVertexFormatMode());
-            GpuBuffer indexBuffer;
-            VertexFormat.IndexType indexType;
-
-            if (buffers.getIndexBuffer() == null)
-            {
-                if (buffers.getIndexCount() > 0)
-                {
-                    indexBuffer = shapeIndexBuffer.getBuffer(buffers.getIndexCount());
-                    indexType = shapeIndexBuffer.type();
-                }
-                else
-                {
-                    LOGGER.error("WorldRendererSchematic#drawInternal() [{}] --> setup IndexBuffer --> NO INDEX COUNT!", buffers.getName());
-                    return;
-                }
-            }
-            else
-            {
-                indexBuffer = buffers.getIndexBuffer();
-                indexType = buffers.getIndexType();
-            }
-
-            GpuBufferSlice gpuSlice = RenderSystem.getDynamicUniforms()
-                                                  .writeTransform(
-                                                          RenderSystem.getModelViewMatrixCopy(),
-                                                          colorMod,
-                                                          modelOffset,
-                                                          texMatrix);
-
-            // Attach Frame buffers
-            try (RenderPass pass = RenderSystem.getDevice()
-                                               .createCommandEncoder()
-                                               .createRenderPass(() -> "litematica:drawInternal/schematic_overlay",
-                                                                 texture1, OptionalInt.empty(),
-                                                                 texture2, OptionalDouble.empty()))
-            {
-                pass.setPipeline(pipeline);
-                RenderSystem.bindDefaultUniforms(pass);
-                pass.setUniform("DynamicTransforms", gpuSlice);
-                pass.setVertexBuffer(0, buffers.getVertexBuffer());
-                pass.setIndexBuffer(indexBuffer, indexType);
-                pass.drawIndexed(0, 0, buffers.getIndexCount(), 1);
-            }
-        }
     }
 
     @Override

--- a/src/main/java/fi/dy/masa/litematica/scheduler/ClientTickHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/ClientTickHandler.java
@@ -23,7 +23,7 @@ public class ClientTickHandler implements IClientTickHandler
                 sm.moveGrabbedElement(mc.player);
             }
 
-            if (mc.screen == null)
+            if (mc.gui.screen() == null)
             {
                 if (Configs.Generic.EASY_PLACE_POST_REWRITE.getBooleanValue())
                 {

--- a/src/main/java/fi/dy/masa/litematica/schematic/LitematicaSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/LitematicaSchematic.java
@@ -972,7 +972,7 @@ public class LitematicaSchematic
     public static boolean isGravityBlock(BlockState state)
     {
         return state.is(BlockTags.SAND) ||
-               state.is(BlockTags.CONCRETE_POWDER) ||
+               state.is(BlockTags.CONCRETE_POWDERS) ||
                state.getBlock() == Blocks.GRAVEL;
     }
 

--- a/src/main/java/fi/dy/masa/litematica/schematic/conversion/SchematicConversionFixers.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/conversion/SchematicConversionFixers.java
@@ -3,8 +3,10 @@ package fi.dy.masa.litematica.schematic.conversion;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.BlockGetter;
@@ -50,26 +52,7 @@ public class SchematicConversionFixers
             if (colorOrig != colorFromData)
             {
                 Integer rotation = state.getValue(BannerBlock.ROTATION);
-
-                switch (colorFromData)
-                {
-                    case WHITE:         state = Blocks.WHITE_BANNER.defaultBlockState();      break;
-                    case ORANGE:        state = Blocks.ORANGE_BANNER.defaultBlockState();     break;
-                    case MAGENTA:       state = Blocks.MAGENTA_BANNER.defaultBlockState();    break;
-                    case LIGHT_BLUE:    state = Blocks.LIGHT_BLUE_BANNER.defaultBlockState(); break;
-                    case YELLOW:        state = Blocks.YELLOW_BANNER.defaultBlockState();     break;
-                    case LIME:          state = Blocks.LIME_BANNER.defaultBlockState();       break;
-                    case PINK:          state = Blocks.PINK_BANNER.defaultBlockState();       break;
-                    case GRAY:          state = Blocks.GRAY_BANNER.defaultBlockState();       break;
-                    case LIGHT_GRAY:    state = Blocks.LIGHT_GRAY_BANNER.defaultBlockState(); break;
-                    case CYAN:          state = Blocks.CYAN_BANNER.defaultBlockState();       break;
-                    case PURPLE:        state = Blocks.PURPLE_BANNER.defaultBlockState();     break;
-                    case BLUE:          state = Blocks.BLUE_BANNER.defaultBlockState();       break;
-                    case BROWN:         state = Blocks.BROWN_BANNER.defaultBlockState();      break;
-                    case GREEN:         state = Blocks.GREEN_BANNER.defaultBlockState();      break;
-                    case RED:           state = Blocks.RED_BANNER.defaultBlockState();        break;
-                    case BLACK:         state = Blocks.BLACK_BANNER.defaultBlockState();      break;
-                }
+                state = Blocks.BANNER.pick(colorFromData).defaultBlockState();
 
                 state = state.setValue(BannerBlock.ROTATION, rotation);
             }
@@ -89,26 +72,7 @@ public class SchematicConversionFixers
             if (colorOrig != colorFromData)
             {
                 Direction facing = state.getValue(WallBannerBlock.FACING);
-
-                switch (colorFromData)
-                {
-                    case WHITE:         state = Blocks.WHITE_WALL_BANNER.defaultBlockState();      break;
-                    case ORANGE:        state = Blocks.ORANGE_WALL_BANNER.defaultBlockState();     break;
-                    case MAGENTA:       state = Blocks.MAGENTA_WALL_BANNER.defaultBlockState();    break;
-                    case LIGHT_BLUE:    state = Blocks.LIGHT_BLUE_WALL_BANNER.defaultBlockState(); break;
-                    case YELLOW:        state = Blocks.YELLOW_WALL_BANNER.defaultBlockState();     break;
-                    case LIME:          state = Blocks.LIME_WALL_BANNER.defaultBlockState();       break;
-                    case PINK:          state = Blocks.PINK_WALL_BANNER.defaultBlockState();       break;
-                    case GRAY:          state = Blocks.GRAY_WALL_BANNER.defaultBlockState();       break;
-                    case LIGHT_GRAY:    state = Blocks.LIGHT_GRAY_WALL_BANNER.defaultBlockState(); break;
-                    case CYAN:          state = Blocks.CYAN_WALL_BANNER.defaultBlockState();       break;
-                    case PURPLE:        state = Blocks.PURPLE_WALL_BANNER.defaultBlockState();     break;
-                    case BLUE:          state = Blocks.BLUE_WALL_BANNER.defaultBlockState();       break;
-                    case BROWN:         state = Blocks.BROWN_WALL_BANNER.defaultBlockState();      break;
-                    case GREEN:         state = Blocks.GREEN_WALL_BANNER.defaultBlockState();      break;
-                    case RED:           state = Blocks.RED_WALL_BANNER.defaultBlockState();        break;
-                    case BLACK:         state = Blocks.BLACK_WALL_BANNER.defaultBlockState();      break;
-                }
+                state = Blocks.WALL_BANNER.pick(colorFromData).defaultBlockState();
 
                 state = state.setValue(WallBannerBlock.FACING, facing);
             }
@@ -127,26 +91,7 @@ public class SchematicConversionFixers
             BedPart part = state.getValue(BedBlock.PART);
             Boolean occupied = state.getValue(BedBlock.OCCUPIED);
 
-            switch (colorId)
-            {
-                case  0: state = Blocks.WHITE_BED.defaultBlockState(); break;
-                case  1: state = Blocks.ORANGE_BED.defaultBlockState(); break;
-                case  2: state = Blocks.MAGENTA_BED.defaultBlockState(); break;
-                case  3: state = Blocks.LIGHT_BLUE_BED.defaultBlockState(); break;
-                case  4: state = Blocks.YELLOW_BED.defaultBlockState(); break;
-                case  5: state = Blocks.LIME_BED.defaultBlockState(); break;
-                case  6: state = Blocks.PINK_BED.defaultBlockState(); break;
-                case  7: state = Blocks.GRAY_BED.defaultBlockState(); break;
-                case  8: state = Blocks.LIGHT_GRAY_BED.defaultBlockState(); break;
-                case  9: state = Blocks.CYAN_BED.defaultBlockState(); break;
-                case 10: state = Blocks.PURPLE_BED.defaultBlockState(); break;
-                case 11: state = Blocks.BLUE_BED.defaultBlockState(); break;
-                case 12: state = Blocks.BROWN_BED.defaultBlockState(); break;
-                case 13: state =  Blocks.GREEN_BED.defaultBlockState(); break;
-                case 14: state = Blocks.RED_BED.defaultBlockState(); break;
-                case 15: state = Blocks.BLACK_BED.defaultBlockState(); break;
-                default: return state;
-            }
+            state = getBedStateFromLegacyColor(colorId, state);
 
             state = state.setValue(BedBlock.FACING, facing)
                          .setValue(BedBlock.PART, part)
@@ -524,6 +469,20 @@ public class SchematicConversionFixers
 
         return getRepeaterPowerOnSide(reader, pos.relative(sideLeft) , sideLeft ) > 0 ||
                getRepeaterPowerOnSide(reader, pos.relative(sideRight), sideRight) > 0;
+    }
+
+    private static BlockState getBedStateFromLegacyColor(int colorId, BlockState fallbackState)
+    {
+        if (colorId < 0 || colorId > 15)
+        {
+            return fallbackState;
+        }
+
+        DyeColor color = DyeColor.byId(colorId);
+        Identifier id = Identifier.withDefaultNamespace(color.getName() + "_bed");
+        Block bedBlock = BuiltInRegistries.BLOCK.getValue(id);
+
+        return bedBlock instanceof BedBlock ? bedBlock.defaultBlockState() : fallbackState;
     }
 
     private static int getRepeaterPowerOnSide(BlockGetter reader, BlockPos pos, Direction side)

--- a/src/main/java/fi/dy/masa/litematica/schematic/placement/SchematicPlacementManager.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/placement/SchematicPlacementManager.java
@@ -230,7 +230,7 @@ public class SchematicPlacementManager
                             if (!this.worldSupplier.get().getChunkSource().hasChunk(cx, cz) &&
                                 DataManager.getSchematicPlacementManager().canHandleChunk(Minecraft.getInstance().level, cx, cz))
                             {
-                                Frustum frustum = Minecraft.getInstance().gameRenderer.getMainCamera().getCapturedFrustum();
+                                Frustum frustum = Minecraft.getInstance().gameRenderer.mainCamera().getCapturedFrustum();
 
                                 // Check Frustum culling
                                 if (frustum != null)

--- a/src/main/java/fi/dy/masa/litematica/util/EntityUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/EntityUtils.java
@@ -14,6 +14,7 @@ import net.minecraft.client.entity.ClientMannequin;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.UUIDUtil;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
@@ -270,6 +271,12 @@ public class EntityUtils
         return entitytype.canSerialize() && id != null ? id.toString() : null;
     }
 
+    private static boolean isEntityType(Entity entity, String path)
+    {
+        Identifier id = BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType());
+        return id != null && id.equals(Identifier.withDefaultNamespace(path));
+    }
+
     @Nullable
     private static Entity createEntityFromNBTSingle(CompoundTag nbt, Level world)
     {
@@ -282,7 +289,7 @@ public class EntityUtils
             {
                 Entity entity = optional.get();
 
-                if (entity.getType().equals(EntityType.MANNEQUIN))
+                if (isEntityType(entity, "mannequin"))
                 {
                     ClientMannequin cm = new ClientMannequin(world, Minecraft.getInstance().playerSkinRenderCache());
                     cm.load(view.getReader());

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
     "accessWidener": "litematica.accesswidener",
 
 	"depends": {
-		"minecraft": "~26.1-",
+		"minecraft": ">=26.2-alpha.5 <26.3-",
 		"malilib": ">=0.28.3- <0.29.0-"
 	},
 	"breaks": {

--- a/src/main/resources/mixins.litematica.json
+++ b/src/main/resources/mixins.litematica.json
@@ -40,6 +40,7 @@
         "hud.MixinDebugScreenOverlay",
         "model.IMixinBlockModelSet",
         "model.IMixinBlockStateModelSet",
+        "model.IMixinEntityRenderDispatcher",
         "model.IMixinEntityModelSet",
         "model.IMixinFluidStateModelSet",
         "model.IMixinMinecraft",


### PR DESCRIPTION
This is a draft port of Litematica to Minecraft **26.2-snapshot-5**.

This PR depends on the matching MaLiLib 26.2-snapshot-5 port:
https://github.com/sakura-ryoko/malilib/pull/148

### Changes
- Updated build/version metadata for 26.2-snapshot-5
- Updated Minecraft API usages that changed in 26.2
- Updated registry/tag lookups for removed direct constants
- Updated renderer/mixin hook points for the 26.2 render flow
- Fixed schematic ghost rendering under the new renderer
- Fixed schematic selection boxes/traces/overlay rendering with the 26.2 reversed-depth behavior
- Fixed schematic status overlay colors
- Added a cached GPU path for schematic status overlays to avoid per-frame rebuilding on large schematics
- Added cache invalidation when schematic layer mode/range changes, so chunks no longer keep stale rendering after switching to layer modes

### Rendering notes
The original status overlay path did not render correctly after the 26.2 renderer changes. The working fix keeps the overlay output correct and uses a cached GPU-buffer path for performance. The previous per-frame fallback was visually correct but too expensive for very large schematics.

Layer mode/range changes also needed explicit invalidation of schematic render caches. Without that, some chunks could keep stale render data until a block update forced a rebuild.

### Notes/limitations
This was tested primarily with Litematica itself and the matching MaLiLib port. I have not tested every possible interaction with other rendering mods or shader mods, so there may still be compatibility issues with certain mod combinations.

This is opened as a draft because 26.2 is still a snapshot target and Mojang may still change rendering internals before the final release.