### PR TITLE
Add: Keep changing layer while holding layerNext/Previous hotkeys

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/scheduler/ClientTickHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/ClientTickHandler.java
@@ -1,12 +1,12 @@
 package fi.dy.masa.litematica.scheduler;
 
 import fi.dy.masa.malilib.interfaces.IClientTickHandler;
-import fi.dy.masa.malilib.util.EntityUtils;
 import net.minecraft.client.Minecraft;
 import fi.dy.masa.litematica.config.Configs;
 import fi.dy.masa.litematica.data.DataManager;
 import fi.dy.masa.litematica.selection.SelectionManager;
 import fi.dy.masa.litematica.util.EasyPlaceUtils;
+import fi.dy.masa.litematica.util.LayerUtils;
 import fi.dy.masa.litematica.util.WorldUtils;
 
 public class ClientTickHandler implements IClientTickHandler
@@ -35,11 +35,7 @@ public class ClientTickHandler implements IClientTickHandler
                 }
             }
 
-            if (Configs.Generic.LAYER_MODE_DYNAMIC.getBooleanValue())
-            {
-                DataManager.getRenderLayerRange().setSingleBoundaryToPosition(EntityUtils.getCameraEntity());
-            }
-
+            LayerUtils.onClientTick(mc);
             DataManager.getSchematicPlacementManager().onClientTick(mc);
             TaskScheduler.getInstanceClient().runTasks();
         }

--- a/src/main/java/fi/dy/masa/litematica/util/LayerUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/LayerUtils.java
@@ -1,0 +1,57 @@
+package fi.dy.masa.litematica.util;
+
+import net.minecraft.client.Minecraft;
+import fi.dy.masa.malilib.util.EntityUtils;
+import fi.dy.masa.litematica.config.Configs;
+import fi.dy.masa.litematica.config.Hotkeys;
+import fi.dy.masa.litematica.data.DataManager;
+
+public class LayerUtils
+{
+    private static final long LAYER_REPEAT_DELAY_MS = 400;
+    private static final long LAYER_REPEAT_INTERVAL_MS = 50;
+
+    private static int layerRepeatDir = 0;
+    private static long layerRepeatStartTime;
+    private static long layerLastRepeatTime;
+
+    public static void onClientTick(Minecraft mc)
+    {
+        if (Configs.Generic.LAYER_MODE_DYNAMIC.getBooleanValue())
+        {
+            DataManager.getRenderLayerRange().setSingleBoundaryToPosition(EntityUtils.getCameraEntity());
+        }
+        else if (mc.screen == null)
+        {
+            layerChangeRepeatTick();
+        }
+    }
+
+    public static void layerChangeRepeatTick()
+    {
+        boolean nextHeld = Hotkeys.LAYER_NEXT.getKeybind().isKeybindHeld();
+        boolean prevHeld = Hotkeys.LAYER_PREVIOUS.getKeybind().isKeybindHeld();
+        int currentDir = nextHeld ? 1 : (prevHeld ? -1 : 0);
+        long now = System.currentTimeMillis();
+
+        if (currentDir != 0)
+        {
+            if (layerRepeatDir != currentDir)
+            {
+                layerRepeatDir = currentDir;
+                layerRepeatStartTime = now;
+                layerLastRepeatTime = now;
+            }
+            else if (now - layerRepeatStartTime >= LAYER_REPEAT_DELAY_MS &&
+                     now - layerLastRepeatTime >= LAYER_REPEAT_INTERVAL_MS)
+            {
+                DataManager.getRenderLayerRange().moveLayer(currentDir);
+                layerLastRepeatTime = now;
+            }
+        }
+        else
+        {
+            layerRepeatDir = 0;
+        }
+    }
+}


### PR DESCRIPTION
This is a small quality of life improvement that allows players to hold layerNext/layerPrevious hotkeys and it will keep changing layers at fast pace instead of having to press the hotkey every time.

I have also moved the LAYER_MODE_DYNAMIC to the new LayerUtils file to collocate layer related tick stuff, but can adjust that if necessary.